### PR TITLE
Set num_threads by cython openmp call

### DIFF
--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -672,7 +672,7 @@ def recon(sino, angles, dist_source_detector, magnification,
     sino = np.swapaxes(sino, 1, 2)
     weights = np.swapaxes(weights, 1, 2)
     x = ci.recon_cy(sino, weights, init_image, proxmap_input,
-                    sinoparams, imgparams, reconparams, sysmatrix_fname)
+                    sinoparams, imgparams, reconparams, sysmatrix_fname, num_threads)
 
     # Convert shape from Cython interface specifications to Python interface specifications
     x = np.swapaxes(x, 0, 2)
@@ -760,6 +760,7 @@ def project(image, angles,
     settings['imgparams'] = imgparams
     settings['sinoparams'] = sinoparams
     settings['sysmatrix_fname'] = sysmatrix_fname
+    settings['num_threads'] = num_threads
 
     image = np.swapaxes(image, 0, 2)
     proj = ci.project(image, settings)

--- a/mbircone/interface_cy_c.pyx
+++ b/mbircone/interface_cy_c.pyx
@@ -3,6 +3,7 @@ import numpy as np
 import ctypes           # Import python package required to use cython
 cimport cython          # Import cython package
 cimport numpy as cnp    # Import specialized cython support for numpy
+cimport openmp
 from libc.string cimport memset,strcpy
 
 
@@ -266,7 +267,7 @@ def AmatrixComputeToFile_cy(angles, sinoparams, imgparams, Amatrix_fname, verbos
 
 
 def recon_cy(sino, wght, x_init, proxmap_input,
-             sinoparams, imgparams, reconparams, py_Amatrix_fname):
+             sinoparams, imgparams, reconparams, py_Amatrix_fname, num_threads):
     # sino, wght shape : views x slices x channels
     # recon shape: N_x N_y N_z (source-detector-line, channels, slices)
 
@@ -300,6 +301,8 @@ def recon_cy(sino, wght, x_init, proxmap_input,
                           &cy_weightScaler_domain[0],
                           &cy_NHICD_Mode[0])
 
+    openmp.omp_set_num_threads(num_threads)
+
     recon(&py_x[0,0,0],
           &cy_sino[0,0,0],
           &cy_wght[0,0,0],
@@ -329,6 +332,9 @@ def project(image, settings):
     imgparams = settings['imgparams']
     sinoparams = settings['sinoparams']
     sysmatrix_fname = settings['sysmatrix_fname']
+    num_threads = settings['num_threads']
+
+    openmp.omp_set_num_threads(num_threads)
 
     # Get shapes of projection
     num_views = sinoparams['N_beta']


### PR DESCRIPTION
Implement the same modification on setting the number of threads by cython openmp call as 
[svmbir's commit](https://github.com/cabouman/svmbir/commit/403faba9452c545bbc6640043512a2201e8c808e#) in prerelease branch.

I tested it in the Lilly cluster. All demos work and the num_threads got set correctly.