### PR TITLE
Add dask to docs requirements.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,4 @@ sphinx-rtd-theme~=0.5.1
 psutil~=5.8.0
 Cython~=0.29.21
 dask~=2021.9.0
-dask-jobqueue~=0.7.3
+dask_jobqueue~=0.7.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,4 @@ sphinx-rtd-theme~=0.5.1
 psutil~=5.8.0
 Cython~=0.29.21
 dask~=2021.9.0
-dask_jobqueue~=0.7.3
+dask-jobqueue~=0.7.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,5 @@ ruamel.yaml~=0.16.12
 sphinx-rtd-theme~=0.5.1
 psutil~=5.8.0
 Cython~=0.29.21
+dask~=2021.9.0
+dask-jobqueue~=0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy~=1.19.5
 Cython~=0.29.24
 psutil~=5.8.0
 Pillow~=8.4.0
-dask
-dask_jobqueue
+dask~=2021.9.1
+dask_jobqueue~=0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Cython~=0.29.24
 psutil~=5.8.0
 Pillow~=8.4.0
 dask~=2021.9.1
-dask_jobqueue~=0.7.3
+dask-jobqueue~=0.7.3


### PR DESCRIPTION
We want to generate API webpages on readthedocs. Previously, we got empty webpages and now I make a fix for it.

The fix may need Prof. Bouman's help.

1. Enable the option  **Install Project** under Admin -> Advanced Settings on readthedocs as shown in the above figure. 
I highlight the section, Prof. Bouman @cabouman can try to enable the option.

![readthedoc_setup](https://user-images.githubusercontent.com/22163570/144878081-c2a60cfc-cc48-4f6f-834d-8b957092ba92.png)


2. To ensure readthedocs can build all API references(cone3D, mace, multinode), I add required packages to docs/requirements.txt in this PR.

Here is the built webpage for API reference. https://mbircone-wenrui.readthedocs.io/en/latest/cone3D.html
I fork mbircone to my own account and tested it on readthedocs.

