### PR TITLE
Convert double to float data type in C code to reduce memory usage (issue #45)

### DIFF
--- a/mbircone/interface_cy_c.pyx
+++ b/mbircone/interface_cy_c.pyx
@@ -14,33 +14,33 @@ cdef extern from "./src/MBIRModularUtilities3D.h":
     
         long int N_dv;
         long int N_dw; 
-        double Delta_dv;
-        double Delta_dw;
+        float Delta_dv;
+        float Delta_dw;
        
         long int N_beta;
         
-        double u_s;
-        double u_r;
-        double v_r;
-        double u_d0;
-        double v_d0;
-        double w_d0;
+        float u_s;
+        float u_r;
+        float v_r;
+        float u_d0;
+        float v_d0;
+        float w_d0;
         
-        double weightScaler_value; 
+        float weightScaler_value; 
 
 
     struct ImageParams:
 
-        double x_0;
-        double y_0;
-        double z_0;
+        float x_0;
+        float y_0;
+        float z_0;
 
         long int N_x;
         long int N_y;
         long int N_z;
 
-        double Delta_xy;
-        double Delta_z;
+        float Delta_xy;
+        float Delta_z;
         
         long int j_xstart_roi;
         long int j_ystart_roi;
@@ -57,31 +57,31 @@ cdef extern from "./src/MBIRModularUtilities3D.h":
 
     struct ReconParams:
     
-        double priorWeight_QGGMRF;                  # Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) 
-        double priorWeight_proxMap;                  # Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) 
+        float priorWeight_QGGMRF;                  # Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) 
+        float priorWeight_proxMap;                  # Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) 
         
         # QGGMRF 
-        double q;                   # q: QGGMRF parameter (q>1, typical choice q=2) 
-        double p;                   # p: QGGMRF parameter (1<=p<q) 
-        double T;                   # T: QGGMRF parameter 
-        double sigmaX;              # sigmaX: QGGMRF parameter 
-        double bFace;               # bFace: relative neighbor weight: cube faces 
-        double bEdge;               # bEdge: relative neighbor weight: cube edges 
-        double bVertex;             # bVertex: relative neighbor weight: cube vertices 
+        float q;                   # q: QGGMRF parameter (q>1, typical choice q=2) 
+        float p;                   # p: QGGMRF parameter (1<=p<q) 
+        float T;                   # T: QGGMRF parameter 
+        float sigmaX;              # sigmaX: QGGMRF parameter 
+        float bFace;               # bFace: relative neighbor weight: cube faces 
+        float bEdge;               # bEdge: relative neighbor weight: cube edges 
+        float bVertex;             # bVertex: relative neighbor weight: cube vertices 
         # Proximal Mapping 
-        double sigma_lambda;        # sigma_lambda: Proximal mapping scalar 
+        float sigma_lambda;        # sigma_lambda: Proximal mapping scalar 
         int is_positivity_constraint;
         
 
          # Stopping Conditions
 
-        double stopThresholdChange_pct;           # stop threshold (%) 
-        double stopThesholdRWFE_pct;
-        double stopThesholdRUFE_pct;
+        float stopThresholdChange_pct;           # stop threshold (%) 
+        float stopThesholdRWFE_pct;
+        float stopThesholdRUFE_pct;
         int MaxIterations;              # maximum number of iterations 
         char relativeChangeMode[200];
-        double relativeChangeScaler;
-        double relativeChangePercentile;
+        float relativeChangeScaler;
+        float relativeChangePercentile;
     
     
          # Zipline Stuff
@@ -96,14 +96,14 @@ cdef extern from "./src/MBIRModularUtilities3D.h":
 
         char weightScaler_estimateMode[200];     # Estimate weight scaler? 1: Yes. 0: Use user specified value 
         char weightScaler_domain[200];     
-        double weightScaler_value;            # User specified weight scaler 
+        float weightScaler_value;            # User specified weight scaler 
     
     
         # NHICD stuff 
         char NHICD_Mode[200];
-        double NHICD_ThresholdAllVoxels_ErrorPercent;
-        double NHICD_percentage;
-        double NHICD_random;
+        float NHICD_ThresholdAllVoxels_ErrorPercent;
+        float NHICD_percentage;
+        float NHICD_random;
     
         # Misc 
         int verbosity;
@@ -112,7 +112,7 @@ cdef extern from "./src/MBIRModularUtilities3D.h":
 
 # Import a c function to compute A matrix.
 cdef extern from "./src/interface.h":
-    void AmatrixComputeToFile(double *angles, SinoParams c_sinoparams, ImageParams c_imgparams, 
+    void AmatrixComputeToFile(float *angles, SinoParams c_sinoparams, ImageParams c_imgparams, 
         char *Amatrix_fname, char verbose);
 
     void recon(float *x, float *sino, float *wght, float *x_init, float *proxmap_input,
@@ -256,7 +256,7 @@ def AmatrixComputeToFile_cy(angles, sinoparams, imgparams, Amatrix_fname, verbos
     # Get pointer to 1D char array of Amatrix 
     cdef cnp.ndarray[char, ndim=1, mode="c"] c_Amatrix_fname
     # Get pointer to 1D array of angles
-    cdef cnp.ndarray[double, ndim=1, mode="c"] c_angles = angles
+    cdef cnp.ndarray[float, ndim=1, mode="c"] c_angles = angles.astype(np.single)
 
     convert_py2c_SinoParams3D(&c_sinoparams, sinoparams)
     convert_py2c_ImageParams3D(&c_imgparams, imgparams)

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -274,17 +274,17 @@ def NSI_read_params(config_file_path):
     params = _NSI_read_str_from_config(config_file_path, tag_section_list)
     NSI_system_params = dict()
 
-    NSI_system_params['u_s'] = np.double(params[0].split(' ')[-1])
+    NSI_system_params['u_s'] = np.single(params[0].split(' ')[-1])
 
     vals = params[1].split(' ')
-    NSI_system_params['u_d1'] = np.double(vals[2])
-    NSI_system_params['v_d1'] = np.double(vals[0])
+    NSI_system_params['u_d1'] = np.single(vals[2])
+    NSI_system_params['v_d1'] = np.single(vals[0])
 
-    NSI_system_params['w_d1'] = np.double(vals[1])
+    NSI_system_params['w_d1'] = np.single(vals[1])
 
     vals = params[2].split(' ')
-    NSI_system_params['delta_dv'] = np.double(vals[0])
-    NSI_system_params['delta_dw'] = np.double(vals[1])
+    NSI_system_params['delta_dv'] = np.single(vals[0])
+    NSI_system_params['delta_dw'] = np.single(vals[1])
 
     NSI_system_params['N_dv'] = int(params[3])
     NSI_system_params['N_dw'] = int(params[4])
@@ -385,7 +385,7 @@ def obtain_sino(path_radiographs, num_views, path_blank=None, path_dark=None,
 
         - **sino** (*ndarray, float*): Preprocessed 3D sinogram.
 
-        - **angles** (*array, double*): 1D array of angles corresponding to preprocessed sinogram.
+        - **angles** (*array, single*): 1D array of angles corresponding to preprocessed sinogram.
 
     """
 

--- a/mbircone/src/MBIRModularUtilities3D.c
+++ b/mbircone/src/MBIRModularUtilities3D.c
@@ -9,7 +9,7 @@
 void forwardProject3DCone( float ***Ax, float ***x, struct ImageParams *imgParams, struct SysMatrix *A, struct SinoParams *sinoParams)
 {
     long int j_u, j_x, j_y, i_beta, i_v, j_z, i_w;
-    double B_ij, B_ij_times_x_j;
+    float B_ij, B_ij_times_x_j;
 
     setFloatArray2Value( &Ax[0][0][0], sinoParams->N_beta*sinoParams->N_dv*sinoParams->N_dw, 0);
 
@@ -44,8 +44,8 @@ void backProjectlike3DCone( float ***x_out, float ***y_in, struct ImageParams *i
 {
 
     long int j_u, j_x, j_y, i_beta, i_v, j_z, i_w;
-    double B_ij, A_ij;
-    double ticToc;
+    float B_ij, A_ij;
+    float ticToc;
     float ***normalization, val, val2;
 
 
@@ -145,8 +145,8 @@ void backProjectlike3DCone( float ***x_out, float ***y_in, struct ImageParams *i
 void initializeWghtRecon(struct SysMatrix *A, struct Sino *sino, struct Image *img, struct ReconParams *reconParams)
 {
     long int j_u, j_x, j_y, i_beta, i_v, j_z, i_w;
-    double B_ij, A_ij;
-    double ticToc, avg;
+    float B_ij, A_ij;
+    float ticToc, avg;
 
     if (reconParams->verbosity>0)
         printf("\nInitialize WghtRecon ...\n");
@@ -205,11 +205,11 @@ void initializeWghtRecon(struct SysMatrix *A, struct Sino *sino, struct Image *i
 
 }
 
-double computeAvgWghtRecon(struct Image *img)
+float computeAvgWghtRecon(struct Image *img)
 {
     long int j_x, j_y, j_z;
 
-    double sum = 0;
+    float sum = 0;
     long int num = 0;
 
     #pragma omp parallel for private(j_y, j_z) reduction(+:sum,num)
@@ -232,7 +232,7 @@ double computeAvgWghtRecon(struct Image *img)
 
 void computeSecondaryReconParams(struct ReconParams *reconParams, struct ImageParams *imgParams)
 {
-    double sum;
+    float sum;
     int N_max, N_z;
 
     sum = 0;
@@ -257,15 +257,15 @@ void computeSecondaryReconParams(struct ReconParams *reconParams, struct ImagePa
 
     N_z = imgParams->N_z;
     N_max = reconParams->numVoxelsPerZiplineMax;
-    reconParams->numVoxelsPerZipline = ceil((double)N_z / ceil((double)N_z/N_max));
+    reconParams->numVoxelsPerZipline = ceil((float)N_z / ceil((float)N_z/N_max));
 
-    reconParams->numZiplines = ceil((double)N_z / reconParams->numVoxelsPerZipline);
+    reconParams->numZiplines = ceil((float)N_z / reconParams->numVoxelsPerZipline);
 
 }
 
-void invertDoubleMatrix(double **A, double ** A_inv, int size)
+void invertDoubleMatrix(float **A, float ** A_inv, int size)
 {
-    double det;
+    float det;
     if(size == 1)
     {
         A_inv[0][0] = 1.0 / A[0][0];
@@ -292,11 +292,11 @@ void invertDoubleMatrix(double **A, double ** A_inv, int size)
     }
 }
 
-double computeNormSquaredFloatArray(float *arr, long int len)
+float computeNormSquaredFloatArray(float *arr, long int len)
 {
     /* out = ||x||^2*/
     long int i;
-    double out = 0;
+    float out = 0;
     for (i = 0; i < len; ++i)
     {
         out += (arr[i]*arr[i]);
@@ -304,7 +304,7 @@ double computeNormSquaredFloatArray(float *arr, long int len)
     return out;
 }
 
-double computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len)
+float computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len)
 {
     /**
      *      out = sqrt(numerator/denominator)
@@ -312,7 +312,7 @@ double computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len)
      *      numerator = ||x1-x2||^2     denominator = ||max(x1,x2)||^2
      */
     long int i;
-    double numerator = 0, denominator = 0, m;
+    float numerator = 0, denominator = 0, m;
     for (i = 0; i < len; ++i)
     {
         numerator += (arr1[i]-arr2[i])*(arr1[i]-arr2[i]);
@@ -323,7 +323,7 @@ double computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len)
 }
 
 
-double computeSinogramWeightedNormSquared(struct Sino *sino, float ***arr)
+float computeSinogramWeightedNormSquared(struct Sino *sino, float ***arr)
 {
     /**
      *                      1  ||     ||2   
@@ -336,7 +336,7 @@ double computeSinogramWeightedNormSquared(struct Sino *sino, float ***arr)
      */
     long int i_beta, i_v, i_w;
     long int num_mask;
-    double normError = 0;
+    float normError = 0;
 
     for (i_beta = 0; i_beta < sino->params.N_beta; ++i_beta)
     for (i_v = 0; i_v < sino->params.N_dv; ++i_v)
@@ -358,9 +358,9 @@ char isInsideMask(long int i_1, long int i_2, long int N1, long int N2)
     /**
      *      returns 1 iff pixel is inside the ellipse that fits in the rectangle
      */
-    double center_1, center_2;
-    double radius_1, radius_2;
-    double reldistance;
+    float center_1, center_2;
+    float radius_1, radius_2;
+    float reldistance;
 
     center_1 = (N1-1.0)/2.0;
     center_2 = (N2-1.0)/2.0;
@@ -442,7 +442,7 @@ void applyMask(float ***arr, long int N1, long int N2, long int N3)
     }
 }
 
-void floatArray_z_equals_aX_plus_bY(float *Z, double a, float *X, double b, float *Y, long int len)
+void floatArray_z_equals_aX_plus_bY(float *Z, float a, float *X, float b, float *Y, long int len)
 {
     long int i;
 
@@ -709,16 +709,16 @@ void shuffleLongIntArray(long int *arr, long int len)
  *      bernoulli(P/100)==1 is true with probability P[%]
  */     
         
-int bernoulli(double p)
+int bernoulli(float p)
 {
-    double r;
+    float r;
     if(p==0)
         return 0;
 
     if(p==1)
         return 1;
 
-    r = ((double) rand() / (RAND_MAX));
+    r = ((float) rand() / (RAND_MAX));
     if(r<p)
         return 1;
     else
@@ -730,13 +730,13 @@ long int uniformIntegerRV(long int l, long int h)
     return l+rand()%(h-l+1);
 }
 
-long int almostUniformIntegerRV(double mean, int sigma)
+long int almostUniformIntegerRV(float mean, int sigma)
 {
     /* creates random integer, Z, variable that is approx uniform in [mean-sigma, mean+sigma] */
     /* "mean" corresponds to the real expectation of Z*/
     /* range(Z) = 2*simga + 1 - delta(mean-ceil(mean)) */
-    double mean_low, mean_high;
-    double X_low, X_high;
+    float mean_low, mean_high;
+    float X_low, X_high;
     int b;
 
     mean_low = floor(mean);
@@ -753,30 +753,30 @@ long int almostUniformIntegerRV(double mean, int sigma)
 
 
 /**************************************** tic toc ****************************************/
-void tic(double *ticToc)
+void tic(float *ticToc)
 {
     (*ticToc) = -omp_get_wtime();
 }
 
-void toc(double *ticToc)
+void toc(float *ticToc)
 {
     (*ticToc) += omp_get_wtime();
 }
 
-void ticTocDisp(double ticToc, char *ticTocName)
+void ticTocDisp(float ticToc, char *ticTocName)
 {
     printf("[ticToc] %s = %e s\n", ticTocName, ticToc);
 }
 
 /**************************************** timer ****************************************/
-void timer_reset(double *timer)
+void timer_reset(float *timer)
 {
     (*timer) = -omp_get_wtime();
 }
 
-int timer_hasPassed(double *timer, double time_passed)
+int timer_hasPassed(float *timer, float time_passed)
 {
-    double time_now;
+    float time_now;
     time_now = omp_get_wtime();
     if ((*timer) + time_now > time_passed )
     {
@@ -945,16 +945,16 @@ void printFileIOInfo( char* functionName, char* fName, long int size, char mode)
     printf(" ****  File access in: %s\n", functionName);
     printf("*****  File name     : %s\n", fName);
     printf("*****  %-14s: %-15ld bytes\n", readwrite, size);
-    printf("*****                = %-15e kB\n", (double) size*1e-3);
-    printf(" ****                = %-15e MB\n", (double) size*1e-6);
+    printf("*****                = %-15e kB\n", (float) size*1e-3);
+    printf(" ****                = %-15e MB\n", (float) size*1e-6);
     printf("    ***********************************************************\n");
 }
 
 void printProgressOfLoop( long int indexOfLoop, long int NumIterations)
 {
-    double percent;
+    float percent;
 
-    percent = (double) (1+indexOfLoop) / (double) NumIterations * 100;
+    percent = (float) (1+indexOfLoop) / (float) NumIterations * 100;
     printf("\r[%.1e%%]", percent );
     fflush(stdout); 
 

--- a/mbircone/src/MBIRModularUtilities3D.h
+++ b/mbircone/src/MBIRModularUtilities3D.h
@@ -127,9 +127,9 @@ struct ImageParams
 {
     /* Location of the corner of the first voxel corresponding to
      (j_x, j_y, j_z) = (0, 0, 0). */
-    double x_0;
-    double y_0;
-    double z_0;
+    float x_0;
+    float y_0;
+    float z_0;
     
     /* Number of voxels in x, y, z direction. */
     long int N_x;
@@ -137,8 +137,8 @@ struct ImageParams
     long int N_z;
 
     /* Dimensions of a voxel */
-    double Delta_xy;
-    double Delta_z;
+    float Delta_xy;
+    float Delta_z;
     
     /**
      *      Region of Interest (roi) parameters
@@ -183,27 +183,27 @@ struct SinoParams
     long int N_dw;
 
     /* Detector width and spacing in v-direction and w-direction. */
-    double Delta_dv;
-    double Delta_dw;
+    float Delta_dv;
+    float Delta_dw;
 
     /* Number of discrete view angles. */
     long int N_beta;
     
     /* The source location on the u-axis. Assume u_s < 0. */
-    double u_s;
+    float u_s;
     
     /* The location (u_r, v_r) of the center of rotation. */
-    double u_r;
-    double v_r;
+    float u_r;
+    float v_r;
     
     /* The location (u,v,w) of the corner of the first detector corresponding to
      (i_v, i_w) = (0, 0). All points on the detector have u = u_d0. */
-    double u_d0;
-    double v_d0;
-    double w_d0;
+    float u_d0;
+    float v_d0;
+    float w_d0;
     
     /* Noise variance estimation */
-    double weightScaler_value;       /* Weight_true = Weight / weightScaler_value */
+    float weightScaler_value;       /* Weight_true = Weight / weightScaler_value */
 };
 
 
@@ -222,7 +222,7 @@ struct Sino
 struct ViewAngleList
 {
     long int N_beta;
-    double *beta;
+    float *beta;
 };
 
 
@@ -232,31 +232,31 @@ struct ReconParams
     /**
      *     Prior
      */
-    double priorWeight_QGGMRF;                  /* Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) */
-    double priorWeight_proxMap;                  /* Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) */
+    float priorWeight_QGGMRF;                  /* Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) */
+    float priorWeight_proxMap;                  /* Prior mode: (0: off, 1: QGGMRF, 2: proximal mapping) */
     
     /* QGGMRF */
-        double q;                   /* q: QGGMRF parameter (q>1, typical choice q=2) */
-        double p;                   /* p: QGGMRF parameter (1<=p<q) */
-        double T;                   /* T: QGGMRF parameter */
-        double sigmaX;              /* sigmaX: QGGMRF parameter */
-        double bFace;               /* bFace: relative neighbor weight: cube faces */
-        double bEdge;               /* bEdge: relative neighbor weight: cube edges */
-        double bVertex;             /* bVertex: relative neighbor weight: cube vertices */
+        float q;                   /* q: QGGMRF parameter (q>1, typical choice q=2) */
+        float p;                   /* p: QGGMRF parameter (1<=p<q) */
+        float T;                   /* T: QGGMRF parameter */
+        float sigmaX;              /* sigmaX: QGGMRF parameter */
+        float bFace;               /* bFace: relative neighbor weight: cube faces */
+        float bEdge;               /* bEdge: relative neighbor weight: cube edges */
+        float bVertex;             /* bVertex: relative neighbor weight: cube vertices */
     /* Proximal Mapping */
-        double sigma_lambda;        /* sigma_lambda: Proximal mapping scalar */
+        float sigma_lambda;        /* sigma_lambda: Proximal mapping scalar */
         int is_positivity_constraint;
     
     /**
      *      Stopping Conditions
      */
-    double stopThresholdChange_pct;           /* stop threshold (%) */
-    double stopThesholdRWFE_pct;
-    double stopThesholdRUFE_pct;
+    float stopThresholdChange_pct;           /* stop threshold (%) */
+    float stopThesholdRWFE_pct;
+    float stopThesholdRUFE_pct;
     int MaxIterations;              /* maximum number of iterations */
     char relativeChangeMode[200];
-    double relativeChangeScaler;
-    double relativeChangePercentile;
+    float relativeChangeScaler;
+    float relativeChangePercentile;
 
 
     /**
@@ -273,14 +273,14 @@ struct ReconParams
      */
     char weightScaler_estimateMode[200];     /* Estimate weight scaler? 1: Yes. 0: Use user specified value */
     char weightScaler_domain[200];     
-    double weightScaler_value;            /* User specified weight scaler */
+    float weightScaler_value;            /* User specified weight scaler */
 
 
     /* NHICD stuff */
     char NHICD_Mode[200];
-    double NHICD_ThresholdAllVoxels_ErrorPercent;
-    double NHICD_percentage;
-    double NHICD_random;
+    float NHICD_ThresholdAllVoxels_ErrorPercent;
+    float NHICD_percentage;
+    float NHICD_random;
 
     /* Misc */
     int verbosity;
@@ -293,14 +293,14 @@ struct SysMatrix
     long int i_vstride_max;        /* max_{i,j}(i_vstride) */
     long int i_wstride_max;        /* max_{i,j}(i_wstride) */
     long int N_u;
-    double B_ij_max;
-    double C_ij_max;
-    double B_ij_scaler;  /* B_ij_true = B_ij * B_ij_scaler*/
-    double C_ij_scaler;  /* C_ij_true = C_ij * C_ij_scaler*/
+    float B_ij_max;
+    float C_ij_max;
+    float B_ij_scaler;  /* B_ij_true = B_ij * B_ij_scaler*/
+    float C_ij_scaler;  /* C_ij_true = C_ij * C_ij_scaler*/
 
-    double Delta_u;     /* = Delta_xy / rho      */
-    double u_0;
-    double u_1;
+    float Delta_u;     /* = Delta_xy / rho      */
+    float u_0;
+    float u_1;
 
     BIJDATATYPE ***B;                   /* [N_x][N_y][N_beta*i_vstride_max]  */
     INDEXSTARTSTOPDATATYPE ***i_vstart; /* [N_x][N_y][N_beta]           */
@@ -326,29 +326,29 @@ struct ICDInfo3DCone
 
     float neighborsFace[6], neighborsEdge[12], neighborsVertex[8];
     float lastChange;
-    double old_xj; /* current pixel value */
-    double wghtRecon_j;
+    float old_xj; /* current pixel value */
+    float wghtRecon_j;
 
     /**
      *      The following is arbitrary when "ICDStep3DCone" is called
      *      and will be used as as variables inside "ICDStep3DCone".
      */
-    double Delta_xj;          /* Delta_xj = x_j^new - x_j^old */
-    double proxMapInput_j;    /* jth voxel of the proxMapInput */
+    float Delta_xj;          /* Delta_xj = x_j^new - x_j^old */
+    float proxMapInput_j;    /* jth voxel of the proxMapInput */
 
-    double theta1_f;
-    double theta2_f;
-    double theta1_p_QGGMRF;
-    double theta2_p_QGGMRF;
-    double theta1_p_proxMap;
-    double theta2_p_proxMap;
+    float theta1_f;
+    float theta2_f;
+    float theta1_p_QGGMRF;
+    float theta2_p_QGGMRF;
+    float theta1_p_proxMap;
+    float theta2_p_proxMap;
 
 };
 
 struct PartialTheta
 {
-    double t1;
-    double t2;
+    float t1;
+    float t2;
 };
 
 struct ParallelAux
@@ -358,28 +358,28 @@ struct ParallelAux
     struct PartialTheta **partialTheta;     /* [numThreads][N_M_max] */
     long int *j_u;
     long int *i_v;
-    double *B_ij;
+    float *B_ij;
     long int *k_M;
     long int *j_z;
     long int *i_w;
-    double *A_ij;
+    float *A_ij;
 };
 
 struct SpeedAuxICD
 {
     long int numberUpdatedVoxels;
-    double tic;
-    double toc;
-    double voxelsPerSecond;    
+    float tic;
+    float toc;
+    float voxelsPerSecond;    
 };
 
 struct IterationStatistics
 {
-    double cost;
-    double relUpdate;
-    double weightScaler_value;
-    double voxelsPerSecond;
-    double ticToc_iteration;
+    float cost;
+    float relUpdate;
+    float weightScaler_value;
+    float voxelsPerSecond;
+    float ticToc_iteration;
 };
 
 
@@ -387,18 +387,18 @@ struct ReconAux
 { 
     int NHICD_isPartialUpdateActive;
     long int *NHICD_numUpdatedVoxels;
-    double *NHICD_totalValueChange;
+    float *NHICD_totalValueChange;
     int *NHICD_isPartialZiplineHot;
     
-    double lastChangeThreshold;
+    float lastChangeThreshold;
     int N_M_max;
-    double totalEquits;
+    float totalEquits;
 
-    double relativeWeightedForwardError;
-    double relativeUnweightedForwardError;
+    float relativeWeightedForwardError;
+    float relativeUnweightedForwardError;
 
-    double TotalValueChange;
-    double TotalVoxelValue;
+    float TotalValueChange;
+    float TotalVoxelValue;
     long int NumUpdatedVoxels;
 
     float NHICD_neighborFilter[3][3];
@@ -412,17 +412,17 @@ void backProjectlike3DCone( float ***x_out, float ***y_in, struct ImageParams *i
 
 void initializeWghtRecon(struct SysMatrix *A, struct Sino *sino, struct Image *img, struct ReconParams *reconParams);
 
-double computeAvgWghtRecon(struct Image *img);
+float computeAvgWghtRecon(struct Image *img);
     
 void computeSecondaryReconParams(struct ReconParams *reconParams, struct ImageParams *imgParams);
 
-void invertDoubleMatrix(double **A, double ** A_inv, int size);
+void invertDoubleMatrix(float **A, float ** A_inv, int size);
 
-double computeNormSquaredFloatArray(float *arr, long int len);
+float computeNormSquaredFloatArray(float *arr, long int len);
 
-double computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len);
+float computeRelativeRMSEFloatArray(float *arr1, float *arr2, long int len);
 
-double computeSinogramWeightedNormSquared(struct Sino *sino, float ***arr);
+float computeSinogramWeightedNormSquared(struct Sino *sino, float ***arr);
 
 char isInsideMask(long int i_1, long int i_2, long int N1, long int N2);
 
@@ -432,7 +432,7 @@ void copyImage2ROI(struct Image *img);
 
 void applyMask(float ***arr, long int N1, long int N2, long int N3);
 
-void floatArray_z_equals_aX_plus_bY(float *Z, double a, float *X, double b, float *Y, long int len);
+void floatArray_z_equals_aX_plus_bY(float *Z, float a, float *X, float b, float *Y, long int len);
 
 void setFloatArray2Value(float *arr, long int len, float value);
 
@@ -472,26 +472,26 @@ void shuffleIntArray(int *arr, long int len);
 
 void shuffleLongIntArray(long int *arr, long int len);
 
-int bernoulli(double p);
+int bernoulli(float p);
 
 long int uniformIntegerRV(long int l, long int h);
 
-long int almostUniformIntegerRV(double mean, int sigma);
+long int almostUniformIntegerRV(float mean, int sigma);
 
 
 
 /**************************************** tic toc ****************************************/
-void tic(double *ticToc);
+void tic(float *ticToc);
 
-void toc(double *ticToc);
+void toc(float *ticToc);
 
-void ticTocDisp(double ticToc, char *ticTocName);
+void ticTocDisp(float ticToc, char *ticTocName);
 
 /**************************************** timer ****************************************/
 
-void timer_reset(double *timer);
+void timer_reset(float *timer);
 
-int timer_hasPassed(double *timer, double time_passed);
+int timer_hasPassed(float *timer, float time_passed);
 
 
 /**************************************** percentile stuff ****************************************/

--- a/mbircone/src/computeSysMatrix.c
+++ b/mbircone/src/computeSysMatrix.c
@@ -5,7 +5,7 @@
 
 void computeSysMatrix(struct SinoParams *sinoParams, struct ImageParams *imgParams, struct SysMatrix *A, struct ViewAngleList *viewAngleList)
 {
-	double ticToc;
+	float ticToc;
 	tic(&ticToc);
     
     // printf("\nInitialize Sinogram Mask ...\n");
@@ -31,24 +31,24 @@ void computeSysMatrix(struct SinoParams *sinoParams, struct ImageParams *imgPara
 void computeAMatrixParameters(struct SinoParams *sinoParams, struct ImageParams *imgParams, struct SysMatrix *A, struct ViewAngleList *viewAngleList)
 {
 	/* Part 1: Find i_vstride_max, u_0, u_1 */
-	double x_v, y_v;
-	double u_v, v_v, w_v;
-	double beta, alpha_xy, theta;
-	double cosine, sine;
-	double W_pv, W_pw, M;
+	float x_v, y_v;
+	float u_v, v_v, w_v;
+	float beta, alpha_xy, theta;
+	float cosine, sine;
+	float W_pv, W_pw, M;
 	long int j_x, j_y, i_beta, i_vstart, i_vstride, i_wstart, i_wstride, j_u, j_z;
 
 
 	long int i_vstride_max = 0, i_wstride_max = 0;
-	double u_0 = INFINITY;
-	double u_1 = -INFINITY;
+	float u_0 = INFINITY;
+	float u_1 = -INFINITY;
 
-	double B_ij_max = 0;
-	double C_ij_max = 0;
-	double delta_v;
-	double delta_w;
-	double L_v;
-	double L_w;
+	float B_ij_max = 0;
+	float C_ij_max = 0;
+	float delta_v;
+	float delta_w;
+	float L_v;
+	float L_w;
 	int temp_stop;
 
 	for (j_x = 0; j_x <= imgParams->N_x-1; ++j_x)
@@ -173,16 +173,16 @@ void computeAMatrixParameters(struct SinoParams *sinoParams, struct ImageParams 
 void computeBMatrix(struct SinoParams *sinoParams, struct ImageParams *imgParams, struct SysMatrix *A, struct ViewAngleList *viewAngleList)
 {
 	/* Variable declarations */
-	double x_v, y_v;
-	double u_v, v_v;
-	double beta, theta, alpha_xy;
-	double cosine, sine;
-	double W_pv, M;
-	double v_d;
-	double delta_v;
-	double L_v;
-	double B_ij;
-	double temp_stop;
+	float x_v, y_v;
+	float u_v, v_v;
+	float beta, theta, alpha_xy;
+	float cosine, sine;
+	float W_pv, M;
+	float v_d;
+	float delta_v;
+	float L_v;
+	float B_ij;
+	float temp_stop;
 
 	long int j_x, j_y, i_beta, i_v;
 
@@ -258,13 +258,13 @@ void computeBMatrix(struct SinoParams *sinoParams, struct ImageParams *imgParams
 
 void computeCMatrix( struct SinoParams *sinoParams, struct ImageParams *imgParams, struct SysMatrix *A)
 {
-        double u_v, w_v;
-        double M;
-        double W_pw;
-        double w_d;
-        double delta_w;
-        double L_w;
-        double C_ij;
+        float u_v, w_v;
+        float M;
+        float W_pw;
+        float w_d;
+        float delta_w;
+        float L_w;
+        float C_ij;
 
         long int j_u, j_z, i_w;
         int temp_stop;
@@ -343,13 +343,13 @@ void writeSysMatrix(char *fName, struct SinoParams *sinoParams, struct ImagePara
     totsize += keepWritingToBinaryFile(fp, &(A->i_vstride_max),     1, sizeof(long int), fName);
     totsize += keepWritingToBinaryFile(fp, &(A->i_wstride_max),     1, sizeof(long int), fName);
     totsize += keepWritingToBinaryFile(fp, &(A->N_u),               1, sizeof(long int), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->B_ij_max),          1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->C_ij_max),          1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->B_ij_scaler),       1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->C_ij_scaler),       1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->Delta_u),           1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->u_0),               1, sizeof(double), fName);
-    totsize += keepWritingToBinaryFile(fp, &(A->u_1),               1, sizeof(double), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->B_ij_max),          1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->C_ij_max),          1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->B_ij_scaler),       1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->C_ij_scaler),       1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->Delta_u),           1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->u_0),               1, sizeof(float), fName);
+    totsize += keepWritingToBinaryFile(fp, &(A->u_1),               1, sizeof(float), fName);
 
     /**
      *      Writing array variables
@@ -408,13 +408,13 @@ void readSysMatrix(char *fName, struct SinoParams *sinoParams, struct ImageParam
     totsize += keepReadingFromBinaryFile(fp, &(A->i_vstride_max),   1, sizeof(long int), fName);
     totsize += keepReadingFromBinaryFile(fp, &(A->i_wstride_max),   1, sizeof(long int), fName);
     totsize += keepReadingFromBinaryFile(fp, &(A->N_u),             1, sizeof(long int), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->B_ij_max),        1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->C_ij_max),        1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->B_ij_scaler),     1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->C_ij_scaler),     1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->Delta_u),         1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->u_0),             1, sizeof(double), fName);
-    totsize += keepReadingFromBinaryFile(fp, &(A->u_1),             1, sizeof(double), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->B_ij_max),        1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->C_ij_max),        1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->B_ij_scaler),     1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->C_ij_scaler),     1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->Delta_u),         1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->u_0),             1, sizeof(float), fName);
+    totsize += keepReadingFromBinaryFile(fp, &(A->u_1),             1, sizeof(float), fName);
 
     /**
      *          Note: Allocation has to happen here (after reading part of the file).
@@ -455,7 +455,7 @@ void readSysMatrix(char *fName, struct SinoParams *sinoParams, struct ImageParam
 
 void allocateSysMatrix(struct SysMatrix *A, long int N_x, long int N_y, long int N_z, long int N_beta, long int i_vstride_max, long int i_wstride_max, long int N_u)
 {
-    /*double totSizeGB;*/
+    /*float totSizeGB;*/
 
     /*
     totSizeGB =\

--- a/mbircone/src/icd3d.c
+++ b/mbircone/src/icd3d.c
@@ -154,7 +154,7 @@ void computeTheta1Theta2ForwardTerm(struct Sino *sino, struct SysMatrix *A, stru
 
 	long int i_beta, i_v, i_w;
 	long int j_x, j_y, j_z, j_u;
-	double B_ij, A_ij;
+	float B_ij, A_ij;
 
 	j_x = icdInfo->j_x;
 	j_y = icdInfo->j_y;
@@ -214,13 +214,13 @@ void computeTheta1Theta2PriorTermQGGMRF(struct ICDInfo3DCone *icdInfo, struct Re
      */
 
 	int i;
-	double delta, surrogateCoeff;
-	double sum1Face = 0;
-	double sum1Edge = 0;
-	double sum1Vertex = 0;
-	double sum2Face = 0;
-	double sum2Edge = 0;
-	double sum2Vertex = 0;
+	float delta, surrogateCoeff;
+	float sum1Face = 0;
+	float sum1Edge = 0;
+	float sum1Vertex = 0;
+	float sum2Face = 0;
+	float sum2Edge = 0;
+	float sum2Vertex = 0;
 
 	if (reconParams->bFace>=0)
 	{
@@ -277,15 +277,15 @@ void computeTheta1Theta2PriorTermProxMap(struct ICDInfo3DCone *icdInfo, struct R
 	icdInfo->theta2_p_proxMap = 1.0 / (reconParams->sigma_lambda * reconParams->sigma_lambda);
 }
 
-double surrogateCoeffQGGMRF(double Delta, struct ReconParams *reconParams)
+float surrogateCoeffQGGMRF(float Delta, struct ReconParams *reconParams)
 {
 	/**
 	 * 				 		 /  rho'(Delta) / (2 Delta) 			if Delta != 0
 	 *   surrCoeff(Delta) = {
 	 * 				 		 \	rho''(0) / 2 						if Delta = 0
 	 */
-    double p, q, T, sigmaX, qmp;
-    double num, denom, temp;
+    float p, q, T, sigmaX, qmp;
+    float num, denom, temp;
     
     p = reconParams->p;
     q = reconParams->q;
@@ -333,7 +333,7 @@ void updateErrorSinogram(struct Sino *sino, struct SysMatrix *A, struct ICDInfo3
 
 	long int i_beta, i_v, i_w;
 	long int j_x, j_y, j_z, j_u;
-	double B_ij;
+	float B_ij;
 
 	j_x = icdInfo->j_x;
 	j_y = icdInfo->j_y;
@@ -399,12 +399,12 @@ void indexExtraction3D(long int j_xyz, long int *j_x, long int N_x, long int *j_
 }
 
 
-double MAPCost3D(struct Sino *sino, struct Image *img, struct ReconParams *reconParams)
+float MAPCost3D(struct Sino *sino, struct Image *img, struct ReconParams *reconParams)
 {
 	/**
 	 *      Computes MAP cost function
 	 */
-	double cost;
+	float cost;
 
     // Initialize cost with forward model cost	
     cost = MAPCostForward(sino);
@@ -421,13 +421,13 @@ double MAPCost3D(struct Sino *sino, struct Image *img, struct ReconParams *recon
 }
 
 
-double MAPCostForward(struct Sino *sino)
+float MAPCostForward(struct Sino *sino)
 {
 	/**
 	 * 		ForwardCost =  1/2 ||e||^{2}_{W}
 	 */
 	long int i_beta, i_v, i_w;
-	double cost;
+	float cost;
 
     cost = 0;
     for (i_beta = 0; i_beta < sino->params.N_beta; ++i_beta)
@@ -445,7 +445,7 @@ double MAPCostForward(struct Sino *sino)
     return cost / (2.0 * sino->params.weightScaler_value);
 }
 
-double MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams)
+float MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams)
 {
 	/**
 	 *	cost = sum     b_{s,r}  rho(x_s-x_r)
@@ -454,8 +454,8 @@ double MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams)
 	
 	long int j_x, j_y, j_z;
 	struct ICDInfo3DCone icdInfo;
-	double cost;
-	double temp;
+	float cost;
+	float temp;
     
     cost = 0;
 	for (j_x = 0; j_x < img->params.N_x; ++j_x)
@@ -478,7 +478,7 @@ double MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams)
 	return cost * reconParams->priorWeight_QGGMRF;
 }
 
-double MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams)
+float MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams)
 {
     /**
      * 			Compute proximal mapping prior cost
@@ -489,7 +489,7 @@ double MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams)
      */
     
     long int j_x, j_y, j_z;
-    double cost, diff_voxel;
+    float cost, diff_voxel;
 
     cost = 0; 
     for (j_x = 0; j_x < img->params.N_x; ++j_x)
@@ -507,7 +507,7 @@ double MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams)
     return cost;
 }
 
-double MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icdInfo, struct ReconParams *reconParams)
+float MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icdInfo, struct ReconParams *reconParams)
 {
     /**
      * 			Compute prior model term of theta1 and theta2:
@@ -518,7 +518,7 @@ double MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icd
      */
 
 	int i;
-	double sum1Face, sum1Edge, sum1Vertex;
+	float sum1Face, sum1Edge, sum1Vertex;
 
     sum1Face = 0;
     sum1Edge = 0;
@@ -544,10 +544,10 @@ double MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icd
 
 
 /* the potential function of the QGGMRF prior model.  p << q <= 2 */
-double QGGMRFPotential(double delta, struct ReconParams *reconParams)
+float QGGMRFPotential(float delta, struct ReconParams *reconParams)
 {
-    double p, q, T, sigmaX;
-    double temp, GGMRF_Pot;
+    float p, q, T, sigmaX;
+    float temp, GGMRF_Pot;
     
     p = reconParams->p;
     q = reconParams->q;
@@ -613,7 +613,7 @@ void computeDeltaXjAndUpdate(struct ICDInfo3DCone *icdInfo, struct ReconParams *
 	 * 		
 	 * 		Delta_xj = clip{   -theta1/theta2, [-x_j, inf)   }
 	 */
-	double theta1, theta2;
+	float theta1, theta2;
 
 	theta1 = icdInfo->theta1_f + reconParams->priorWeight_QGGMRF*icdInfo->theta1_p_QGGMRF + reconParams->priorWeight_proxMap*icdInfo->theta1_p_proxMap;
 	theta2 = icdInfo->theta2_f + reconParams->priorWeight_QGGMRF*icdInfo->theta2_p_QGGMRF + reconParams->priorWeight_proxMap*icdInfo->theta2_p_proxMap;
@@ -672,7 +672,7 @@ void computeDeltaXjAndUpdateGroup(struct ICDInfo3DCone *icdInfo, struct RandomZi
 void updateIterationStatsGroup(struct ReconAux *reconAux, struct ICDInfo3DCone *icdInfoArray, struct RandomZiplineAux *randomZiplineAux, struct Image *img, struct ReconParams *reconParams)
 {
 	long int N_M, k_M;
-	double absDelta, totValue;
+	float absDelta, totValue;
 	struct ICDInfo3DCone *icdInfo;
 	long int j_x, j_y, j_z;
 	long int indexZiplines;
@@ -705,7 +705,7 @@ void updateIterationStatsGroup(struct ReconAux *reconAux, struct ICDInfo3DCone *
 }
 
 
-void disp_iterationInfo(struct ReconAux *reconAux, struct ReconParams *reconParams, int itNumber, int MaxIterations, double cost, double relUpdate, double stopThresholdChange, double weightScaler_value, double voxelsPerSecond, double ticToc_iteration, double weightedNormSquared_e, double ratioUpdated, double totalEquits)
+void disp_iterationInfo(struct ReconAux *reconAux, struct ReconParams *reconParams, int itNumber, int MaxIterations, float cost, float relUpdate, float stopThresholdChange, float weightScaler_value, float voxelsPerSecond, float ticToc_iteration, float weightedNormSquared_e, float ratioUpdated, float totalEquits)
 {
 	printf("************************** Iteration %-2d (max. %d) **************************\n", itNumber, MaxIterations);
 	printf("*  Cost                   = %-10.10e\n", cost);
@@ -723,11 +723,11 @@ void disp_iterationInfo(struct ReconAux *reconAux, struct ReconParams *reconPara
 	printf("******************************************************************************\n\n");
 }
 
-double computeRelUpdate(struct ReconAux *reconAux, struct ReconParams *reconParams, struct Image *img)
+float computeRelUpdate(struct ReconAux *reconAux, struct ReconParams *reconParams, struct Image *img)
 {
-	double relUpdate;
-	double AvgValueChange, AvgVoxelValue;
-	double scaler;
+	float relUpdate;
+	float AvgValueChange, AvgVoxelValue;
+	float scaler;
 	int subsampleFactor = 10; /* when chosen 1 this is completely accurate. User can mess with this to some extend*/
 
 	if(reconAux->NumUpdatedVoxels>0)
@@ -789,11 +789,11 @@ void prepareParallelAux(struct ParallelAux *parallelAux, long int N_M_max)
 
 	parallelAux->j_u = mem_alloc_1D(numThreads, sizeof(long int));
 	parallelAux->i_v = mem_alloc_1D(numThreads, sizeof(long int));
-	parallelAux->B_ij = mem_alloc_1D(numThreads, sizeof(double));
+	parallelAux->B_ij = mem_alloc_1D(numThreads, sizeof(float));
 	parallelAux->k_M = mem_alloc_1D(numThreads, sizeof(long int));
 	parallelAux->j_z = mem_alloc_1D(numThreads, sizeof(long int));
 	parallelAux->i_w = mem_alloc_1D(numThreads, sizeof(long int));
-	parallelAux->A_ij = mem_alloc_1D(numThreads, sizeof(double));
+	parallelAux->A_ij = mem_alloc_1D(numThreads, sizeof(float));
 
 }
 
@@ -841,7 +841,7 @@ void computeTheta1Theta2ForwardTermGroup(struct Sino *sino, struct SysMatrix *A,
 
 	long int i_beta, i_v, i_w;
 	long int j_x, j_y, j_z, j_u;
-	double B_ij, A_ij;
+	float B_ij, A_ij;
 	long int N_M, k_M;
 	int threadID;
 
@@ -955,7 +955,7 @@ void updateErrorSinogramGroup(struct Sino *sino, struct SysMatrix *A, struct ICD
 
 	long int i_beta, i_v, i_w;
 	long int j_x, j_y, j_z, j_u;
-	double B_ij;
+	float B_ij;
 
 	N_M = randomZiplineAux->N_M;
 	j_x = icdInfo[0].j_x;
@@ -1022,7 +1022,7 @@ void speedAuxICD_computeSpeed(struct SpeedAuxICD *speedAuxICD)
 	if (speedAuxICD->numberUpdatedVoxels > 0)
 	{
 		speedAuxICD->toc = omp_get_wtime();
-		speedAuxICD->voxelsPerSecond = ((double)speedAuxICD->numberUpdatedVoxels) / (speedAuxICD->toc - speedAuxICD->tic);
+		speedAuxICD->voxelsPerSecond = ((float)speedAuxICD->numberUpdatedVoxels) / (speedAuxICD->toc - speedAuxICD->tic);
 	}
 	else
 	{
@@ -1033,7 +1033,7 @@ void speedAuxICD_computeSpeed(struct SpeedAuxICD *speedAuxICD)
 
 /* * * * * * * * * * * * NHICD * * * * * * * * * * * * **/
 
-int NHICD_isVoxelHot(struct ReconParams *reconParams, struct Image *img, long int j_x, long int j_y, long int j_z, double lastChangeThreshold)
+int NHICD_isVoxelHot(struct ReconParams *reconParams, struct Image *img, long int j_x, long int j_y, long int j_z, float lastChangeThreshold)
 {
     if(img->lastChange[j_x][j_y][j_z] > lastChangeThreshold)
         return 1;
@@ -1044,7 +1044,7 @@ int NHICD_isVoxelHot(struct ReconParams *reconParams, struct Image *img, long in
     return 0;
 }
 
-int NHICD_activatePartialUpdate(struct ReconParams *reconParams, double relativeWeightedForwardError)
+int NHICD_activatePartialUpdate(struct ReconParams *reconParams, float relativeWeightedForwardError)
 {
 	if (relativeWeightedForwardError*100<reconParams->NHICD_ThresholdAllVoxels_ErrorPercent && strcmp(reconParams->NHICD_Mode, "off")!=0)
 		return 1;
@@ -1089,13 +1089,13 @@ void NHICD_checkPartialZiplinesHot(struct ReconAux *reconAux, long int j_x, long
 void updateNHICDStats(struct ReconAux *reconAux, long int j_x, long int j_y, struct Image *img, struct ReconParams *reconParams)
 {
 	long int jj_x, jj_y, jj_x_min, jj_y_min, jj_x_max, jj_y_max;
-	double avgChange;
-	double mean_timeToChange;
+	float avgChange;
+	float mean_timeToChange;
 	long int sigma_timeToChange;
 	long int indexZiplines;
-	double w_self = 1;
-	double w_past = 0.5;
-	double w_neighbors = 0.5;
+	float w_self = 1;
+	float w_past = 0.5;
+	float w_neighbors = 0.5;
 
 
 

--- a/mbircone/src/icd3d.h
+++ b/mbircone/src/icd3d.h
@@ -17,7 +17,7 @@ void computeTheta1Theta2PriorTermQGGMRF(struct ICDInfo3DCone *icdInfo, struct Re
 
 void computeTheta1Theta2PriorTermProxMap(struct ICDInfo3DCone *icdInfo, struct ReconParams *reconParams);
 
-double surrogateCoeffQGGMRF(double Delta, struct ReconParams *reconParams);
+float surrogateCoeffQGGMRF(float Delta, struct ReconParams *reconParams);
 
 void updateErrorSinogram(struct Sino *sino, struct SysMatrix *A, struct ICDInfo3DCone *icdInfo);
 
@@ -32,17 +32,17 @@ void indexExtraction3D(long int j_xyz, long int *j_x, long int N_x, long int *j_
 
 
 
-double MAPCost3D(struct Sino *sino, struct Image *img, struct ReconParams *reconParams);
+float MAPCost3D(struct Sino *sino, struct Image *img, struct ReconParams *reconParams);
 
-double MAPCostForward(struct Sino *sino);
+float MAPCostForward(struct Sino *sino);
 
-double MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams);
+float MAPCostPrior_QGGMRF(struct Image *img, struct ReconParams *reconParams);
 
-double MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams);
+float MAPCostPrior_ProxMap(struct Image *img, struct ReconParams *reconParams);
 
-double MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icdInfo, struct ReconParams *reconParams);
+float MAPCostPrior_QGGMRFSingleVoxel_HalfNeighborhood(struct ICDInfo3DCone *icdInfo, struct ReconParams *reconParams);
 
-double QGGMRFPotential(double delta, struct ReconParams *reconParams);
+float QGGMRFPotential(float delta, struct ReconParams *reconParams);
 
 
 void partialZipline_computeStartStopIndex(long int *j_z_start, long int *j_z_stop, long int indexZiplines, long int numVoxelsPerZipline, long int N_z);
@@ -55,9 +55,9 @@ void computeDeltaXjAndUpdateGroup(struct ICDInfo3DCone *icdInfo, struct RandomZi
 
 void updateIterationStatsGroup(struct ReconAux *reconAux, struct ICDInfo3DCone *icdInfoArray, struct RandomZiplineAux *randomZiplineAux, struct Image *img, struct ReconParams *reconParams);
 
-void disp_iterationInfo(struct ReconAux *reconAux, struct ReconParams *reconParams, int itNumber, int MaxIterations, double cost, double relUpdate, double stopThresholdChange, double weightScaler_value, double voxelsPerSecond, double ticToc_iteration, double weightedNormSquared_e, double ratioUpdated, double totalEquits);
+void disp_iterationInfo(struct ReconAux *reconAux, struct ReconParams *reconParams, int itNumber, int MaxIterations, float cost, float relUpdate, float stopThresholdChange, float weightScaler_value, float voxelsPerSecond, float ticToc_iteration, float weightedNormSquared_e, float ratioUpdated, float totalEquits);
 
-double computeRelUpdate(struct ReconAux *reconAux, struct ReconParams *reconParams, struct Image *img);
+float computeRelUpdate(struct ReconAux *reconAux, struct ReconParams *reconParams, struct Image *img);
 
 /* * * * * * * * * * * * parallel * * * * * * * * * * * * **/
 void prepareParallelAux(struct ParallelAux *parallelAux, long int N_M_max);
@@ -84,9 +84,9 @@ void speedAuxICD_computeSpeed(struct SpeedAuxICD *speedAuxICD);
 
 /* * * * * * * * * * * * NHICD * * * * * * * * * * * * **/
 
-int NHICD_isVoxelHot(struct ReconParams *reconParams, struct Image *img, long int j_x, long int j_y, long int j_z, double lastChangeThreshold);
+int NHICD_isVoxelHot(struct ReconParams *reconParams, struct Image *img, long int j_x, long int j_y, long int j_z, float lastChangeThreshold);
 
-int NHICD_activatePartialUpdate(struct ReconParams *reconParams, double relativeWeightedForwardError);
+int NHICD_activatePartialUpdate(struct ReconParams *reconParams, float relativeWeightedForwardError);
 
 int NHICD_checkPartialZiplineHot(struct ReconAux *reconAux, long int j_x, long int j_y, long int indexZiplines, struct Image *img);
 

--- a/mbircone/src/interface.c
+++ b/mbircone/src/interface.c
@@ -6,7 +6,7 @@
 #include "recon3DCone.h"
 
 
-void AmatrixComputeToFile(double *angles, 
+void AmatrixComputeToFile(float *angles, 
 	struct SinoParams sinoParams, struct ImageParams imgParams, 
 	char *Amatrix_fname, char verbose)
 {

--- a/mbircone/src/interface.h
+++ b/mbircone/src/interface.h
@@ -1,7 +1,7 @@
 #ifndef _CY_INTERFACE_H_
 #define _CY_INTERFACE_H_
 
-void AmatrixComputeToFile(double *angles, 
+void AmatrixComputeToFile(float *angles, 
 	struct SinoParams sinoParams, struct ImageParams imgParams, 
 	char *Amatrix_fname, char verbose);
 

--- a/mbircone/src/recon3DCone.c
+++ b/mbircone/src/recon3DCone.c
@@ -8,8 +8,8 @@
 void MBIR3DCone(struct Image *img, struct Sino *sino, struct ReconParams *reconParams, struct SysMatrix *A)
 {
 	int itNumber = 0, MaxIterations;
-    double stopThresholdChange;
-    double stopThesholdRWFE, stopThesholdRUFE;
+    float stopThresholdChange;
+    float stopThesholdRWFE, stopThesholdRUFE;
 	long int j_xy, j_x, j_y, j_z;
 	long int j_xyz;
 	long int N_x, N_y, N_z;
@@ -17,18 +17,18 @@ void MBIR3DCone(struct Image *img, struct Sino *sino, struct ReconParams *reconP
 	long int k_G, N_G;
 	long int numZiplines;
 	long int numVoxelsInMask;
-    double ratioUpdated;
-    double relUpdate;
+    float ratioUpdated;
+    float relUpdate;
 
-	double timer_icd_loop;
-	double ticToc_icdUpdate;
-	double ticToc_icdUpdate_total;
-	double ticToc_all;
-	double ticToc_randomization;
-	double ticToc_computeCost;
-	double ticToc_computeRelUpdate;
-	double ticToc_iteration;
-	double ticToc_computeLastChangeThreshold;
+	float timer_icd_loop;
+	float ticToc_icdUpdate;
+	float ticToc_icdUpdate_total;
+	float ticToc_all;
+	float ticToc_randomization;
+	float ticToc_computeCost;
+	float ticToc_computeRelUpdate;
+	float ticToc_iteration;
+	float ticToc_computeLastChangeThreshold;
 
 	char stopFlag = 0;
 
@@ -41,9 +41,9 @@ void MBIR3DCone(struct Image *img, struct Sino *sino, struct ReconParams *reconP
 
 
 	/* Iteration statistics */
-	double cost = -1.0;
-	double weightedNormSquared_e, weightedNormSquared_y;
-	double normSquared_e, normSquared_y;
+	float cost = -1.0;
+	float weightedNormSquared_e, weightedNormSquared_y;
+	float normSquared_e, normSquared_y;
 
 
 	struct SpeedAuxICD speedAuxICD;
@@ -77,7 +77,7 @@ void MBIR3DCone(struct Image *img, struct Sino *sino, struct ReconParams *reconP
 	reconAux.relativeWeightedForwardError = 0;
 	reconAux.relativeUnweightedForwardError = 0;
 	reconAux.NHICD_numUpdatedVoxels = (long int*) malloc(numZiplines*sizeof(long int));
-	reconAux.NHICD_totalValueChange = (double*) malloc(numZiplines*sizeof(double));
+	reconAux.NHICD_totalValueChange = (float*) malloc(numZiplines*sizeof(float));
 	reconAux.NHICD_isPartialZiplineHot = (int*) malloc(numZiplines*sizeof(int));
 
 
@@ -293,7 +293,7 @@ void MBIR3DCone(struct Image *img, struct Sino *sino, struct ReconParams *reconP
 		relUpdate = computeRelUpdate(&reconAux, reconParams, img);
 		toc(&ticToc_computeRelUpdate);
 
-        ratioUpdated = (double) reconAux.NumUpdatedVoxels / numVoxelsInMask;
+        ratioUpdated = (float) reconAux.NumUpdatedVoxels / numVoxelsInMask;
         reconAux.totalEquits += ratioUpdated;
 
 		/* NHICD Arrays */


### PR DESCRIPTION
This PR is to handle issue #45.
Recently I've been running large scale CT experiments. I constantly run into out of memory issues on Brown (maximum allowed memory is 91 GB). By converting double to float in C and Cython interface, we are going to be able to save half of the memory space.
Tested with 3D shepp Logan demo. Results are visually the same as before.
Note that you will need to clean up cached system matrix before testing, otherwise there will be a seg fault.