### PR TITLE
Dask 2021.11.2 -> Dask 2022.4.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,5 @@ ruamel.yaml~=0.16.12
 sphinx-rtd-theme~=0.5.1
 psutil~=5.8.0
 Cython~=0.29.21
-dask~=2021.11.2
+dask~=2022.4.0
 dask-jobqueue~=0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy~=1.19.5
 Cython~=0.29.24
 psutil~=5.8.0
 Pillow>=9.1
-dask~=2021.11.2
+dask~=2022.4.0
 dask-jobqueue~=0.7.3


### PR DESCRIPTION
A Dask's required library(Click)'s recent update leads to incompatible.
Update Dask to 2022.4.0 can fix this issue.

By testing multinode module functional functionality, Diyu can just run the dev_scripts to install the package and test dask functionality by running ./demo/demo_multinode_4D_shepp_logan.py.

