### PR TITLE
Fixed readthedoc failed build.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Currently, the readthedoc of mbircone are fail to build.

The reason is that NumPy 1.22.0 does not support Python 3.7(Default Readthedoc Python) anymore. 
The solution is to add a readthedoc configuration file to ask readthedoc to use python 3.9 to build the documentation.

I tested this thing on my fork. It builds successfully. https://readthedocs.org/projects/mbircone-wenrui/builds/.

