### PR TITLE
Memory fix patch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -657,11 +657,6 @@ def recon(sino, angles, dist_source_detector, magnification,
     else:
         reconparams['NHICD_Mode'] = 'off'
 
-    if np.isscalar(init_image):
-        init_image = np.zeros((imgparams['N_x'], imgparams['N_y'], imgparams['N_z'])) + init_image
-    else:
-        init_image = np.swapaxes(init_image, 0, 2)
-
     if prox_image is None:
         reconparams['priorWeight_QGGMRF'] = 1
         reconparams['priorWeight_proxMap'] = -1
@@ -672,16 +667,9 @@ def recon(sino, angles, dist_source_detector, magnification,
         if sigma_p is None:
             sigma_p = auto_sigma_p(sino, delta_pixel_detector, sharpness)
         reconparams['sigma_lambda'] = sigma_p
-        prox_image = np.swapaxes(prox_image, 0, 2)
 
-    sino = np.swapaxes(sino, 1, 2)
-    weights = np.swapaxes(weights, 1, 2)
     x = ci.recon_cy(sino, weights, init_image, prox_image,
                     sinoparams, imgparams, reconparams, sysmatrix_fname, num_threads)
-
-    # Convert shape from Cython interface specifications to Python interface specifications
-    x = np.swapaxes(x, 0, 2)
-
     return x
 
 
@@ -767,9 +755,5 @@ def project(image, angles,
     settings['sysmatrix_fname'] = sysmatrix_fname
     settings['num_threads'] = num_threads
 
-    image = np.swapaxes(image, 0, 2)
     proj = ci.project(image, settings)
-    # Convert shape from Cython interface specifications to Python interface specifications
-    proj = np.swapaxes(proj, 1, 2)
-
     return proj


### PR DESCRIPTION
This is (hopefully) the last merge for the memory fix.
**This PR contains Wenrui's PR #57 for readthedoc fix.**
Additionally, this PR contains the following memory allocation fix:

- In python recon() function, when init_image is provided as a scalar, the construction of the corresponding 3D array is moved from `cone3D.py` to `interface_cy.py` to avoid unnecessary mem alloc and copy of 3D memory space.
- Move all axes swapping into Cython interface.

Both fixes above follows the convention/implementation of svmbir.

**Testing**: Tested with both `demo_3D_shepp_logan.py` and `demo_mace3D.py`.
**Memory usage**: Memory usage (measured before Cython interface invoking C code subroutine) drops from 4075MB down to 2712MB for a problem with sino shape = 144x512x512, recon shape = 799x473x473.