### PR TITLE
Paramfix

### DIFF
--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -32,7 +32,6 @@ num_views = 64
 angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
 # qGGMRF recon parameters
 sharpness = 1.0                             # Controls regularization level of reconstruction by controling prior term weighting
-snr_db = 40                                 # Controls regularization level of reconstruction by controling data term weighting
 T = 0.1                                     # Controls edginess of reconstruction
 # convergence parameters
 stop_threshold = 0.005
@@ -84,7 +83,7 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D qGGMRF reconstruction
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...')
-recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, snr_db = snr_db, T = T, stop_threshold = stop_threshold)
+recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, T = T, stop_threshold = stop_threshold)
 print('recon shape = ', np.shape(recon))
 
 

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -31,9 +31,15 @@ num_views = 64
 # projection angles will be uniformly spaced within the range [0, 2*pi).
 angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
 # qGGMRF recon parameters
-sharpness = 2.0                             # Controls regularization level of reconstruction
-max_iterations=40
-stop_threshold=0.005
+sharpness = 1.0                             # Controls regularization level of reconstruction by controling prior term weighting
+snr_db = 40                                 # Controls regularization level of reconstruction by controling data term weighting
+T = 0.1                                     # Controls edginess of reconstruction
+# convergence parameters
+stop_threshold = 0.005
+# display parameters
+vmin = 0.10
+vmax = 0.12
+
 # local path to save phantom, sinogram, and reconstruction images
 save_path = f'output/3D_shepp_logan/'
 os.makedirs(save_path, exist_ok=True)
@@ -57,8 +63,10 @@ print('ROI shape is:', num_slices_ROI, num_rows_ROI, num_cols_ROI)
 ######################################################################################
 # Generate a 3D shepp logan phantom with size calculated in previous section
 ######################################################################################
-phantom = mbircone.phantom.gen_shepp_logan_3d(num_rows_ROI, num_cols_ROI, num_slices_ROI) # generate phantom within ROI
+phantom = mbircone.phantom.gen_shepp_logan_3d(num_rows_ROI, num_cols_ROI, num_slices_ROI)       # generate phantom within ROI
 phantom = mbircone.cone3D.pad_roi2ror(phantom, boundary_size)                                   # zero-pad phantom to ROR
+# scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
+phantom = phantom/10.0
 print('Padded ROR phantom shape = ', np.shape(phantom))
 
 
@@ -76,17 +84,14 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D qGGMRF reconstruction
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...')
-recon = mbircone.cone3D.recon(sino, angles, 
-                              dist_source_detector, magnification, 
-                              sharpness=sharpness,
-                              max_iterations=max_iterations, stop_threshold=stop_threshold)
+recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, snr_db = snr_db, T = T, stop_threshold = stop_threshold)
 print('recon shape = ', np.shape(recon))
 
 
 ######################################################################################
 # Generate phantom, synthetic sinogram, and reconstruction images
 ######################################################################################
-# Generate sino and recon images
+# sinogram images
 for view_idx in [0, num_views//4, num_views//2]:
     view_angle = int(angles[view_idx]*180/np.pi)
     plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle} ', 
@@ -97,17 +102,21 @@ display_x = num_rows_ROR // 2
 display_y = num_cols_ROR // 2
 # phantom images
 plot_image(phantom[display_slice], title=f'phantom, axial slice {display_slice}', 
-           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=1.0, vmax=1.1)
-plot_image(phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}', 
-           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=1.0, vmax=1.1)
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=0, vmax=0.40)
+plot_image(phantom[display_slice], title=f'phantom, axial slice {display_slice}',
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}',
+           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
 plot_image(phantom[:,:,display_y], title=f'phantom, sagittal slice {display_y}', 
-           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=1.0, vmax=1.1)
+           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
 # recon images
 plot_image(recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}', 
-           filename=os.path.join(save_path, 'recon_axial.png'), vmin=1.0, vmax=1.1)
+           filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
+plot_image(recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}',
+           filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
 plot_image(recon[:,display_x,:], title=f'qGGMRF recon, coronal slice {display_x}', 
-           filename=os.path.join(save_path, 'recon_coronal.png'), vmin=1.0, vmax=1.1)
+           filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
 plot_image(recon[:,:,display_y], title=f'qGGMRF recon, sagittal slice {display_y}', 
-           filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=1.0, vmax=1.1)
+           filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
 print(f"Images saved to {save_path}.") 
 input("Press Enter")

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -122,7 +122,7 @@ def calc_weights(sino, weight_type):
     return weights
 
 
-def auto_sigma_y(sino, magnification, weights, snr_db=30.0, delta_pixel_image=1.0, delta_pixel_detector=1.0):
+def auto_sigma_y(sino, magnification, weights, snr_db=40.0, delta_pixel_image=1.0, delta_pixel_detector=1.0):
     """Compute the automatic value of ``sigma_y`` for use in MBIR reconstruction.
 
     Args:
@@ -132,7 +132,7 @@ def auto_sigma_y(sino, magnification, weights, snr_db=30.0, delta_pixel_image=1.
             numpy array of weights with same shape as sino.
             The parameters weights should be the same values as used in mbircone reconstruction.
         snr_db (float, optional):
-            [Default=30.0] Scalar value that controls assumed signal-to-noise ratio of the data in dB.
+            [Default=40.0] Scalar value that controls assumed signal-to-noise ratio of the data in dB.
         delta_pixel_image (float, optional):
             [Default=1.0] Scalar value of pixel spacing in :math:`ALU`.
         delta_pixel_detector (float, optional):
@@ -484,7 +484,7 @@ def recon(sino, angles, dist_source_detector, magnification,
           channel_offset=0.0, row_offset=0.0, rotation_offset=0.0,
           delta_pixel_detector=1.0, delta_pixel_image=None, ror_radius=None,
           init_image=0.0, prox_image=None,
-          sigma_y=None, snr_db=30.0, weights=None, weight_type='unweighted',
+          sigma_y=None, snr_db=40.0, weights=None, weight_type='unweighted',
           positivity=True, p=1.2, q=2.0, T=1.0, num_neighbors=6,
           sharpness=0.0, sigma_x=None, sigma_p=None, max_iterations=100, stop_threshold=0.02,
           num_threads=None, NHICD=False, verbose=1, lib_path=__lib_path):
@@ -513,7 +513,7 @@ def recon(sino, angles, dist_source_detector, magnification,
         
         sigma_y (float, optional): [Default=None] Scalar value of noise standard deviation parameter.
             If None, automatically set with auto_sigma_y.
-        snr_db (float, optional): [Default=30.0] Scalar value that controls assumed signal-to-noise ratio of the data in dB.
+        snr_db (float, optional): [Default=40.0] Scalar value that controls assumed signal-to-noise ratio of the data in dB.
             Ignored if sigma_y is not None.
         weights (ndarray, optional): [Default=None] 3D weights array with same shape as sino.
         weight_type (string, optional): [Default='unweighted'] Type of noise model used for data.

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -486,7 +486,7 @@ def recon(sino, angles, dist_source_detector, magnification,
           init_image=0.0, prox_image=None,
           sigma_y=None, snr_db=30.0, weights=None, weight_type='unweighted',
           positivity=True, p=1.2, q=2.0, T=1.0, num_neighbors=6,
-          sharpness=0.0, sigma_x=None, sigma_p=None, max_iterations=20, stop_threshold=0.02,
+          sharpness=0.0, sigma_x=None, sigma_p=None, max_iterations=100, stop_threshold=0.02,
           num_threads=None, NHICD=False, verbose=1, lib_path=__lib_path):
     """Compute 3D cone beam MBIR reconstruction
     
@@ -541,7 +541,7 @@ def recon(sino, angles, dist_source_detector, magnification,
         sigma_p (float, optional): [Default=None] Scalar value :math:`>0` that specifies the proximal map parameter.
             Ignored if prox_image is None.
             If None and proximal image is not None, automatically set with auto_sigma_p. Regularization should be controled with the ``sharpness`` parameter, but ``sigma_p`` can be set directly by expert users.
-        max_iterations (int, optional): [Default=20] Integer valued specifying the maximum number of iterations. 
+        max_iterations (int, optional): [Default=100] Integer valued specifying the maximum number of iterations.
         stop_threshold (float, optional): [Default=0.02] Scalar valued stopping threshold in percent.
             If stop_threshold=0.0, then run max iterations.
         num_threads (int, optional): [Default=None] Number of compute threads requested when executed.

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -77,7 +77,7 @@ def gen_microscopy_sample(num_rows, num_cols):
     return image
 
 
-def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(4,4,4)):
+def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2,2,2)):
     """
     Generate a smoothed 3D Shepp Logan phantom with block-averaging strategy.
     


### PR DESCRIPTION
This branch includes some fixes to 3D shepp Logan demo, and some changes regarding default parameter values.
1. In cone3D.recon, changed default max_iterations from 20 to 100 to align with svmbir.
2. In cone3D.recon, changed default snr_db from 30 to 40. **We need to do the same thing for svmbir.**
3. In shepp Logan demo, changed value of T to 0.1 used snr_db=40 (current default value).

Tested and shepp Logan recon results look good.