### PR TITLE
Updating Read Me for mbircone

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install .
 1) Install demo requirements
 ```
 cd demo
-pip install -r requirements.txt
+pip install -r requirements_demo.txt
 ```
 2) Run basic demo
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ conda activate mbircone
 ```
 pip install -r requirements.txt
 ```
-5) Ensure GCC is installed per instructions here
+5) Ensure GCC is installed per instructions here: https://svmbir.readthedocs.io/en/latest/install.html
 
 6) Install package
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ conda activate mbircone
 ```
 pip install -r requirements.txt
 ```
-5) Install package
+5) Ensure GCC is installed per instructions here
+
+6) Install package
 ```
 pip install .
 ```


### PR DESCRIPTION
Following updates have been made to allow for error free installation of mbircone

1) Under "Install Demo Requirements section" changed requirement.txt to requirements_demo.txt
2) Under "Installation Section" included a point to install GCC per the instructions found on SVMBIR page