### PR TITLE
import warnings

### DIFF
--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -6,6 +6,7 @@ import os
 import hashlib
 import mbircone.interface_cy_c as ci
 import random
+import warnings
 
 __lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
 __namelen_sysmatrix = 20


### PR DESCRIPTION
This is a bug fix to cone3D.py. The warnings library is used in cone3D.py, but not imported.