### PR TITLE
remove stop_threshold keyword from demo script

### DIFF
--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -81,7 +81,7 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D qGGMRF reconstruction
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...')
-recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, T = T, stop_threshold = stop_threshold)
+recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, T=T)
 print('recon shape = ', np.shape(recon))
 
 


### PR DESCRIPTION
There is an error in `demo_3D_shepp_logan.py` due to the keyword `stop_threshold`. 
The `stop_threshold` was removed from the script, but we forgot to also remove the keyword when calling `recon()` function.