### PR TITLE
Multires patch

### DIFF
--- a/mbircone/interface_cy_c.pyx
+++ b/mbircone/interface_cy_c.pyx
@@ -313,14 +313,16 @@ def recon_cy(sino, angles, wght, x_init, proxmap_input,
             lr_num_slices, lr_num_rows, lr_num_cols = imgparams_lr['N_z'], imgparams_lr['N_x'], imgparams_lr['N_y']
             print(f'Calling multires_recon for reconstruction size (slices, rows, cols)=({lr_num_slices}, {lr_num_rows},{lr_num_cols}).')
         
-        lr_recon = recon_cy(sino, angles, wght, x_init, proxmap_input,
+        lr_recon = recon_cy(sino, angles, wght, lr_init_image, lr_prox_image,
                             sinoparams, imgparams_lr, reconparams_lr, new_max_resolutions, 
                             num_threads, lib_path)
         
         # Interpolate resolution of reconstruction
         x_init = _utils.recon_resize_3D(lr_recon, (imgparams['N_z'], imgparams['N_x'], imgparams['N_y']))
         del lr_recon
-
+        del lr_init_image
+        del lr_prox_image
+    
     hash_val = _utils.hash_params(angles, sinoparams, imgparams)
     py_Amatrix_fname = _utils._gen_sysmatrix_fname(lib_path=lib_path, sysmatrix_name=hash_val[:__namelen_sysmatrix])
 


### PR DESCRIPTION
This PR is a patch to the multi-resolution functionality.
### This PR includes:
1. **corner case fix.** In lower resolution space recon, pass in downsampled init image and prox image (`lr_init_image` and `lr_prox_image`) if an init image is given at highest resolution space.
  We failed to catch this corner case previously, because non of our previous test cases cover the case of using multi-res and non default init image at the same time.

2. **memory efficency.** Delete low resolution variables once the low resolution recon is done.

### Testing:
1. Ran `demo_3D_shepp_logan.py` and `demo_mace3D.py`, both experiments yield same results and convergence behavior as before.
2. In `demo_3D_shepp_logan.py`, set `init_image = phantom`, and `max_resolutions=2`:
  ```
  init_image = np.copy(phantom)
  recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, init_image=init_image, max_resolutions=2, sharpness=sharpness, T=T)
  ```
  We expect that the convergence in all resolution spaces are fast, because the initial condition is the perfect answer. So the lower resolution space only needs to correct the aliasing resulted from down-sampling.
  **Before the fix**: The lowest resolution recon takes 21 iterations to converge, as a result of incorrect `init_image` provided. 
  **After the fix**: The lowest resolution recon takes 12 iterations to converge.