### PR TITLE
readthedoc fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ psutil~=5.8.0
 Cython~=0.29.21
 dask~=2022.4.1
 dask-jobqueue~=0.7.3
+scipy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,6 @@
 sphinx>=2.2
 sphinxcontrib-bibtex==1.0
 ipython>=6.3.1
-numpy~=1.22.0
 matplotlib~=3.3.4
 ruamel.yaml~=0.16.12
 sphinx-rtd-theme~=0.5.1
-psutil~=5.8.0
-Cython~=0.29.21
-dask~=2022.4.1
-dask-jobqueue~=0.7.3
-scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psutil~=5.8.0
 Pillow>=9.1
 dask~=2022.4.1
 dask-jobqueue~=0.7.3
+scipy


### PR DESCRIPTION
Readthedocs failed to build online because scipy library is recently introduced to the code based, but not included in `docs/requirements.txt`. 
Scipy is used for 3D interpolation in multires.