### PR TITLE
Hotfix docs demos

### DIFF
--- a/demo/debug_forward_proj.py
+++ b/demo/debug_forward_proj.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import mbircone
-from demo_utils import plot_image, plot_gif, plt_cmp_3dobj
+from demo_utils import plot_image, plot_gif
 
 """
 This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes

--- a/demo/debug_forward_proj.py
+++ b/demo/debug_forward_proj.py
@@ -1,0 +1,99 @@
+import os
+import numpy as np
+import mbircone
+from demo_utils import plot_image, plot_gif, plt_cmp_3dobj
+
+"""
+This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes
+ * generating a 3D Shepp Logan phantom, generating synthetic sinogram data by
+ * forward projecting the phantom, performing a 3D qGGMRF reconstruction,
+ * and displaying the results.
+"""
+print('This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes \
+\n\t * generating a 3D Shepp Logan phantom, generating synthetic sinogram data by \
+\n\t * forward projecting the phantom, performing a 3D qGGMRF reconstruction, \
+\n\t * and displaying the results.')
+
+# ###########################################################################
+# Set the parameters to generate the phantom, synthetic sinogram, and do the recon
+# ###########################################################################
+
+# Change the parameters below for your own use case.
+
+# Detector size
+num_det_rows = 9
+num_det_channels = 9
+# Geometry parameters
+magnification = 1.0                   # Ratio of (source to detector)/(source to center of rotation)
+dist_factor = 1.0
+dist_source_detector = dist_factor*10*num_det_channels  # distance from source to detector in ALU
+# number of projection views
+num_views = 64
+# projection angles will be uniformly spaced within the range [0, 2*pi).
+angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
+# qGGMRF recon parameters
+sharpness = 0.0                             # Controls regularization: larger => sharper; smaller => smoother
+T = 0.1                                     # Controls edginess of reconstruction
+# display parameters
+vmin = 0.10
+vmax = 0.12
+
+# Size of phantom
+num_slices_phantom = 9
+num_rows_phantom = 9
+num_cols_phantom = 9
+delta_pixel_phantom = 1
+
+
+# local path to save phantom, sinogram, and reconstruction images
+save_path = f'output/debug_forward_proj_mag_{magnification}_dist_{dist_factor}/'
+os.makedirs(save_path, exist_ok=True)
+
+print('Genrating 3D Shepp Logan phantom ...')
+######################################################################################
+# Generate a 3D shepp logan phantom
+######################################################################################
+
+phantom = np.zeros((num_slices_phantom,num_rows_phantom,num_cols_phantom))
+phantom[4,4,4]=1
+
+######################################################################################
+# Generate synthetic sinogram
+######################################################################################
+
+print('Generating synthetic sinograms ...')
+
+
+start = 0.0
+stop = 1.0
+step = 0.1
+for offset in np.arange(start, stop + step, step):
+  sino = mbircone.cone3D.project(phantom, angles,
+                                 num_det_rows, num_det_channels,
+                                 dist_source_detector, magnification, det_row_offset=offset, delta_pixel_image=delta_pixel_phantom)
+  print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
+
+  ######################################################################################
+  # Generate phantom, synthetic sinogram, and reconstruction images
+  ######################################################################################
+  # sinogram images
+  for view_idx in [0, num_views//4, num_views//2]:
+      view_angle = int(angles[view_idx]*180/np.pi)
+      plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle}, det_row_offset {offset}',
+                 filename=os.path.join(save_path, f'sino-shepp-logan-3D-offset-{offset}-view-angle-{view_angle}.png'))
+  # Set display indexes for phantom and recon images
+  display_slice_phantom = num_slices_phantom // 2
+  display_x_phantom = num_rows_phantom // 2
+  display_y_phantom = num_cols_phantom // 2
+
+# phantom images
+plot_image(phantom[display_slice_phantom], title=f'phantom, axial slice {display_slice_phantom}',
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(phantom[:,display_x_phantom,:], title=f'phantom, coronal slice {display_x_phantom}',
+           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(phantom[:,:,display_y_phantom], title=f'phantom, sagittal slice {display_y_phantom}',
+           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+  
+print(f"Images saved to {save_path}.") 
+input("Press Enter")
+

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import mbircone
-from demo_utils import plot_image, plot_gif, plt_cmp_3dobj
+from demo_utils import plot_image, plot_gif
 
 """
 This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes

--- a/demo/demo_3D_shepp_logan_test.py
+++ b/demo/demo_3D_shepp_logan_test.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import mbircone
-from demo_utils import plot_image, plot_gif, plt_cmp_3dobj
+from demo_utils import plot_image, plot_gif
 
 """
 This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes

--- a/demo/demo_multinode_4D_shepp_logan.py
+++ b/demo/demo_multinode_4D_shepp_logan.py
@@ -1,28 +1,75 @@
-import numpy as np
 import os
+import numpy as np
 import mbircone
+from scipy.ndimage import rotate
 import argparse
-import getpass
 from psutil import cpu_count
-from demo_utils import load_yaml, plt_cmp_3dobj, create_cluster_ticket_configs
-from scipy import ndimage
+from demo_utils import plot_image, plot_gif, create_cluster_ticket_configs
 
 if __name__ == '__main__':
     """
     This script is a demonstration of how to use scatter_gather() to deploy parallel jobs.  Demo functionality includes
-     * obatin cluster ticket with get_cluster_ticket().
+     * obtain cluster ticket with get_cluster_ticket().
      Use scatter_gather to:
-     * generating 4D simulated data by rotating the 3D shepp logan phantom by increasing degree per time point.
-     * generating sinogram data by projecting each phantom in all timepoints.
-     * performing 3D reconstruction in all timepoints.
+     * generate 4D phantom by rotating the 3D shepp logan phantom with positive angular steps with each time point.
+     * generate synthetic sinogram data by forward projecting each phantom in all timepoints.
+     * perform 3D reconstruction in all timepoints.
     """
     print('This script is a demonstration of how to use scatter_gather() to deploy parallel jobs.  Demo functionality includes \
-    \n\t * obatin cluster ticket with get_cluster_ticket(). \
-    \n\t * Use scatter_gather to:\
-    \n\t * generating 4D simulated data by rotating the 3D shepp logan phantom by increasing degree per time point. \
-    \n\t * generating sinogram data by projecting each phantom in all timepoints. \
-    \n\t * performing 3D reconstruction in all timepoints.')
+    \n\t * obtain cluster ticket with get_cluster_ticket(). \
+    \n\t Use scatter_gather to:\
+    \n\t * generate 4D phantom by rotating the 3D shepp logan phantom with positive angular steps with each time point. \
+    \n\t * generate synthetic sinogram data by forward projecting each phantom in all timepoints. \
+    \n\t * perform 3D reconstruction in all timepoints.')
 
+    # ###########################################################################
+    # Set the parameters to generate the phantom, synthetic sinogram, and do the recon
+    # ###########################################################################
+
+    # Change the parameters below for your own use case.
+    # Parallel computation parameters
+    num_time_points = 4 # number of time points
+    par_verbose = 0 # verbosity level for parallel computation
+    # Detector size
+    num_det_rows = 128
+    num_det_channels = 128
+    # Geometry parameters
+    magnification = 2.0                        # Ratio of (source to detector)/(source to center of rotation)
+    dist_source_detector = 10*num_det_channels  # distance from source to detector in ALU
+    # number of projection views
+    num_views = 64
+    # projection angles will be uniformly spaced within the range [0, 2*pi).
+    angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
+    # qGGMRF recon parameters
+    sharpness = 0.0                             # Controls regularization: larger => sharper; smaller => smoother
+    T = 0.1                                     # Controls edginess of reconstruction
+    # display parameters
+    vmin = 0.10
+    vmax = 0.12
+
+    # Size of phantom
+    num_slices_phantom = 128
+    num_rows_phantom = 128
+    num_cols_phantom = 128
+    delta_pixel_phantom = 0.5
+
+    # Size and proportion of phantom within image
+    scale=1.0
+    offset_x=0.0
+    offset_y=0.0
+    offset_z=0.0
+
+    # Size of recon
+    num_slices_recon = 128
+    num_rows_recon = 128
+    num_cols_recon = 128
+    delta_pixel_recon = delta_pixel_phantom
+
+    # local path to save phantom, sinogram, and reconstruction images
+    save_path = f'output/4D_shepp_logan_multinode/'
+    os.makedirs(save_path, exist_ok=True)
+
+    print("Getting cluster ticket for parallel computing ...")
     # ###########################################################################
     # Load the parameters from configuration file to obtain a cluster ticket.
     # ###########################################################################
@@ -35,42 +82,7 @@ if __name__ == '__main__':
     parser.add_argument('--no_multinode', default=False, action='store_true', help="Run this demo in a single node machine.")
     args = parser.parse_args()
     save_config_dir = './configs/multinode/'
-
-    # ###########################################################################
-    # Set the parameters to do the recon
-    # ###########################################################################
-
-    # sinogram parameters
-    num_det_rows = 200
-    num_det_channels = 128
-    num_views = 144
-
-    # Reconstruction parameters
-    sharpness = 0.2
-    snr_db = 31.0
-
-    # magnification is unit-less.
-    magnification = 2
-
-    # All distances are in unit of 1 ALU = 1 mm.
-    dist_source_detector = 600
-    delta_pixel_detector = 0.9
-    delta_pixel_image = 1.0
-    channel_offset = 0
-    row_offset = 0
-    max_iterations = 20
-
-    # Display parameters
-    vmin = 1.0
-    vmax = 1.1
-    filename = 'output/3D_shepp_logan/results_%d.png'
-
-    # Parallel computer verbose
-    par_verbose = 0
-
-    # Number of parallel functions
-    num_parallel = 4
-
+    
     # ###########################################################################
     # Obtain a cluster ticket.
     # ###########################################################################
@@ -104,121 +116,108 @@ if __name__ == '__main__':
             local_directory=configs['cluster_params']['local_directory'],
             log_directory=configs['cluster_params']['log_directory'])
 
+    print('Genrating 3D Shepp Logan phantom ...')
+    ######################################################################################
+    # Generate a 3D shepp logan phantom
+    ######################################################################################
 
-    print(cluster_ticket)
-    print("Parallel computing 3D conebeam reconstruction at %d timepoints.\n" % num_parallel)
-
-    # ###########################################################################
-    # Generate a 3D shepp logan phantom.
-    # ###########################################################################
-
-    ROR, boundary_size = mbircone.cone3D.compute_img_size(num_views, num_det_rows, num_det_channels,
-                                                          dist_source_detector,
-                                                          magnification,
-                                                          channel_offset=channel_offset, row_offset=row_offset,
-                                                          delta_pixel_detector=delta_pixel_detector,
-                                                          delta_pixel_image=delta_pixel_image)
-    Nz, Nx, Ny = ROR
-    img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size = boundary_size
-    print('Region of reconstruction (ROR) shape is:', (Nz, Nx, Ny))
-
-    # Set phantom parameters to generate a phantom inside ROI according to ROR and boundary_size.
-    # All valid pixels should be inside ROI.
-    num_rows_cols = Nx - 2 * img_rows_boundary_size  # Assumes a square image
-    num_slices_phantom = Nz - 2 * img_slices_boundary_size
-    print('Region of interest (ROI) shape is:', num_slices_phantom, num_rows_cols, num_rows_cols)
-
-    # Set display indexes
-    display_slice = img_slices_boundary_size + int(0.4 * num_slices_phantom)
-    display_x = num_rows_cols // 2
-    display_y = num_rows_cols // 2
-    display_view = 0
-
-    # Generate a 3D phantom
-    phantom = mbircone.phantom.gen_shepp_logan_3d(num_rows_cols, num_rows_cols, num_slices_phantom)
-    print('Generated 3D phantom shape before padding = ', np.shape(phantom))
-    phantom = mbircone.cone3D.pad_roi2ror(phantom, boundary_size)
-    print('Padded 3D phantom shape = ', np.shape(phantom))
-    print()
+    phantom_3D = mbircone.phantom.gen_shepp_logan_3d(num_rows_phantom, num_cols_phantom, num_slices_phantom, scale=scale, offset_x=offset_x, offset_y=offset_y, offset_z=offset_z)
+    # scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
+    phantom_3D = phantom_3D/10.0
+    print('3D Phantom shape = ', np.shape(phantom_3D))
 
     # ###########################################################################
     # Generate a 4D shepp logan phantom.
     # ###########################################################################
-
-    print("Generating 4D simulated data by rotating the 3D shepp logan phantom with positive angular steps with each time point ...")
+    print("generate 4D phantom by rotating the 3D phantom with positive angular steps with each time point.")
     # Generate 4D simulated data by rotating the 3D shepp logan phantom by increasing degree per time point.
     # Create the rotation angles and argument lists, and distribute to workers.
-    phantom_rot_para = np.linspace(0, 180, num_parallel, endpoint=False)  # Phantom rotation angles.
-    phantom_list = [ndimage.rotate(input=phantom,
-                                   angle=phantom_rot_ang,
-                                   order=0,
-                                   mode='constant',
-                                   axes=(1, 2),
-                                   reshape=False) for phantom_rot_ang in phantom_rot_para]
-    print()
-
+    tilt_angles = np.linspace(0, 45, num_time_points, endpoint=False)  # Phantom rotation angles.
+    phantom_4D = [rotate(input=phantom_3D,
+                         angle=tilt_ang,
+                         order=0,
+                         mode='constant',
+                         axes=(1, 2),
+                         reshape=False) for tilt_ang in tilt_angles]
+    
     # ###########################################################################
-    # Generate sinogram
+    # Generate synthetic sinogram
     # ###########################################################################
 
-    print("****Multinode computation with Dask****: Generating sinogram data by projecting each phantom at each timepoint ...")
+    print("****Multinode computation with Dask****: Generating synthetic sinogram data by projecting each phantom at each timepoint ...")
     # scatter_gather parallel computes mbircone.cone3D.project
     # Generate sinogram data by projecting each phantom in phantom list.
     # Create the projection angles and argument lists, and distribute to workers.
-    proj_angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)  # Same for all time points.
     # After setting the geometric parameter, the shape of the input phantom should be equal to the calculated
     # geometric parameter. Input a phantom with wrong shape will generate a bunch of issue in C.
-    variable_args_list = [{'image': phantom_rot} for phantom_rot in phantom_list]
-    constant_args = {'angles': proj_angles,
+    variable_args_list = [{'image': phantom_rot} for phantom_rot in phantom_4D]
+    constant_args = {'angles': angles,
                      'num_det_rows': num_det_rows,
                      'num_det_channels': num_det_channels,
                      'dist_source_detector': dist_source_detector,
                      'magnification': magnification,
-                     'delta_pixel_detector': delta_pixel_detector,
-                     'delta_pixel_image': delta_pixel_image,
-                     'channel_offset': channel_offset,
-                     'row_offset': row_offset}
+                     'delta_pixel_image': delta_pixel_phantom}
     sino_list = mbircone.multinode.scatter_gather(cluster_ticket,
                                                   mbircone.cone3D.project,
                                                   constant_args=constant_args,
                                                   variable_args_list=variable_args_list,
 
                                                   verbose=par_verbose)
-    print()
 
     # ###########################################################################
     # Perform multinode reconstruction
     # ###########################################################################
 
-    print("****Multinode computation with Dask****: Reconstructing 3D phantom at all timepoints ...")
+    print("****Multinode computation with Dask****: Performing 3D qGGMRF recon at all time points ...")
     # scatter_gather parallel computes mbircone.cone3D.recon
     # Reconstruct 3D phantom in all timepoints using mbircone.cone3D.recon.
     # Create the projection angles and argument lists, and distribute to workers.
-    angles_list = [np.copy(proj_angles) for i in range(num_parallel)]  # Same for all time points.
+    angles_list = [np.copy(angles) for t in range(num_time_points)]  # Same for all time points.
     variable_args_list = [{'sino': sino, 'angles': angles} for sino, angles in zip(sino_list, angles_list)]
     constant_args = {'dist_source_detector': dist_source_detector,
                      'magnification': magnification,
-                     'delta_pixel_detector': delta_pixel_detector,
-                     'delta_pixel_image': delta_pixel_image,
-                     'channel_offset': channel_offset,
-                     'row_offset': row_offset,
-                     'sharpness': sharpness,
-                     'snr_db': snr_db,
-                     'max_iterations': max_iterations,
-                     'verbose': 0}
+                     'delta_pixel_image': delta_pixel_recon,
+                     'num_image_rows': num_rows_recon, 
+                     'num_image_cols': num_cols_recon, 
+                     'num_image_slices': num_slices_recon, 
+                     'sharpness': sharpness, 
+                     'T': T}
     recon_list = mbircone.multinode.scatter_gather(cluster_ticket,
                                                    mbircone.cone3D.recon,
                                                    constant_args=constant_args,
                                                    variable_args_list=variable_args_list,
                                                    verbose=par_verbose)
 
-    print("Reconstructed 4D image shape = ", np.array(recon_list).shape)
+    print('4D recon shape = ', np.shape(recon_list))
 
-    # create output folder and save reconstruction list
-    os.makedirs('output/3D_shepp_logan/', exist_ok=True)
-    np.save("./output/3D_shepp_logan/recon_sh4d.npy", np.array(recon_list))
+    ######################################################################################
+    # Generate phantom, synthetic sinogram, and reconstruction images
+    ######################################################################################
+    # Set display indexes for phantom and recon images
+    display_slice_phantom = num_slices_phantom // 2
+    display_x_phantom = num_rows_phantom // 2
+    display_y_phantom = num_cols_phantom // 2
+    display_slice_recon = num_slices_recon // 2
+    display_x_recon = num_rows_recon // 2
+    display_y_recon = num_cols_recon // 2
 
-    # Display and compare reconstruction
-    for i in range(num_parallel):
-        plt_cmp_3dobj(phantom_list[i], recon_list[i], display_slice, display_x, display_y, vmin, vmax, filename % i)
-    input("press Enter")
+    for t in range(num_time_points):
+        # phantom images
+        plot_image(phantom_4D[t][display_slice_phantom, :, :], title=f'phantom, axial slice {display_slice_phantom}, time point {t}',
+                   filename=os.path.join(save_path, f'phantom_axial_tp{t}.png'), vmin=vmin, vmax=vmax)
+        plot_image(phantom_4D[t][:,display_x_phantom,:], title=f'phantom, coronal slice {display_x_phantom}, time point {t}',
+                   filename=os.path.join(save_path, f'phantom_coronal_tp{t}.png'), vmin=vmin, vmax=vmax)
+        plot_image(phantom_4D[t][:,:,display_y_phantom], title=f'phantom, sagittal slice {display_y_phantom}, time point {t}',
+                   filename=os.path.join(save_path, f'phantom_sagittal_tp{t}.png'), vmin=vmin, vmax=vmax)
+                   
+        # recon images
+        plot_image(recon_list[t][display_slice_recon, :, :], title=f'qGGMRF recon, axial slice {display_slice_recon}, time point {t}',
+                   filename=os.path.join(save_path, f'recon_axial_tp{t}.png'), vmin=vmin, vmax=vmax)
+        plot_image(recon_list[t][:,display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, time point {t}',
+                   filename=os.path.join(save_path, f'recon_coronal_tp{t}.png'), vmin=vmin, vmax=vmax)
+        plot_image(recon_list[t][:,:,display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, time point {t}',
+                   filename=os.path.join(save_path, f'recon_sagittal_tp{t}.png'), vmin=vmin, vmax=vmax)
+                   
+    print(f"Images saved to {save_path}.") 
+    input("Press Enter")
+

--- a/demo/demo_utils.py
+++ b/demo/demo_utils.py
@@ -56,65 +56,6 @@ def nrmse(image, reference_image):
     return rmse / denominator
 
 
-def plt_cmp_3dobj(phantom, recon, display_slice=None, display_x=None, display_y=None, vmin=None, vmax=None,
-                  filename=None):
-    plt.ion()
-
-    Nz, Nx, Ny = recon.shape
-    if display_slice is None:
-        display_slice = Nz // 2
-    if display_x is None:
-        display_x = Nx // 2
-    if display_y is None:
-        display_y = Ny // 2
-
-    # Compute Normalized Root Mean Squared Error
-    nrmse_1 = nrmse(recon, phantom)
-
-    font_setting()
-
-    # display phantom
-    fig, axs = plt.subplots(2, 3, figsize=(20,10))
-
-    title = f'Phantom: Axial Scan {display_slice:d}.'
-    axs[0, 0].imshow(phantom[display_slice], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[0, 0].set_title(title)
-
-    title = f'Phantom: Coronal Scan {display_x:d}.'
-    axs[0, 1].imshow(phantom[:, display_x, :], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[0, 1].set_title(title)
-
-    title = f'Phantom: Sagittal Scan {display_y:d}.'
-    axs[0, 2].imshow(phantom[:, :, display_y], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[0, 2].set_title(title)
-
-    # display reconstruction
-    title = f'Recon: Axial Scan {display_slice:d}.'
-    axs[1, 0].imshow(recon[display_slice], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[1, 0].set_title(title)
-
-    title = f'Recon: Coronal Scan {display_y:d}.'
-    axs[1, 1].imshow(recon[:, display_x, :], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[1, 1].set_title(title)
-
-    title = f'Recon: Sagittal Scan {display_x:d}.'
-    im = axs[1, 2].imshow(recon[:, :, display_y], vmin=vmin, vmax=vmax, cmap='gray', interpolation='none')
-    axs[1, 2].set_title(title)
-
-    # Add colorbar
-    plt.subplots_adjust(wspace=0.9, hspace=0.4, right=0.8)
-    cax = plt.axes([0.85, 0.15, 0.05, 0.7])
-    plt.colorbar(im, cax=cax)
-
-    plt.suptitle(f"3D Shepp-Logan Recon Phantom VS Recon with NRMSE={nrmse_1:.3f}.")
-
-    if filename is not None:
-        try:
-            plt.savefig(filename, dpi=600)
-        except:
-            print("plot_image() Warning: Can't write to file {}".format(filename))
-
-
 def plot_gif(x, save_dir, name, vmin=None, vmax=None):
     images = []
     for i in range(x.shape[0]):

--- a/docs/source/cone3D.rst
+++ b/docs/source/cone3D.rst
@@ -1,7 +1,7 @@
 mbircone.cone3D
 ---------------
 .. automodule:: mbircone.cone3D
-   :members: auto_sigma_x, auto_sigma_p, auto_sigma_y, calc_weights, compute_img_size, pad_roi2ror, extract_roi_from_ror, project, recon
+   :members: auto_image_size, auto_sigma_x, auto_sigma_p, auto_sigma_y, calc_weights, create_image_params_dict, create_sino_params_dict, project, recon
    :undoc-members:    
    :show-inheritance:
 
@@ -9,12 +9,12 @@ mbircone.cone3D
 
    .. autosummary::
 
+      auto_image_size
       auto_sigma_p
       auto_sigma_x
       auto_sigma_y
       calc_weights
-      compute_img_size
-      extract_roi_from_ror
-      pad_roi2ror
+      create_image_params_dict
+      create_sino_params_dict
       project
       recon

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -228,9 +228,9 @@ def auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_
     
     return (num_image_rows, num_image_cols, num_image_slices)
 
-def auto_image_params(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=1.0, image_slice_offset=0.0):
+def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=1.0, image_slice_offset=0.0):
     """ Allocate imageparam parameters as required by certain C methods.
-        Can be used to describe a region of projection (i.e., when an image is available in ``project'' method), or to specify a region of reconstruction.
+        Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
         For detailed specifications of sinoparams, see cone3D.interface_cy_c
     
     Args:
@@ -274,11 +274,11 @@ def auto_image_params(num_image_rows, num_image_cols, num_image_slices, delta_pi
     return imgparams
 
 
-def compute_sino_params(dist_source_detector, magnification,
+def create_sino_params_dict(dist_source_detector, magnification,
                         num_views, num_det_rows, num_det_channels,
                         det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
                         delta_pixel_detector=1.0):
-    """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram
+    """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram.
         For detailed specifications of sinoparams, see cone3D.interface_cy_c
     
     Args:
@@ -325,41 +325,6 @@ def compute_sino_params(dist_source_detector, magnification,
     sinoparams['weightScaler_value'] = -1
 
     return sinoparams
-
-
-def pad_roi2ror(image, boundary_size):
-    """Given a 3D ROI and the boundary size, pad the ROI with 0s to form an ROR.
-
-    Args:
-        image (ndarray): 3D numpy array with a shape of (num_img_slices, num_img_rows, num_img_cols)
-        boundary_size (list): Number of invalid pixels on each side of a 3D image. A list of 3 integer, [img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size].
-
-    Returns:
-        padded_image: 3D padded image with shape (num_img_slices+2*boundary_size[0], num_img_rows+2*boundary_size[1], num_img_cols+2*boundary_size[2]).
-    """
-    img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size = boundary_size
-    return np.pad(image, ((img_slices_boundary_size, img_slices_boundary_size),
-                          (img_rows_boundary_size, img_rows_boundary_size),
-                          (img_cols_boundary_size, img_cols_boundary_size)), mode='constant', constant_values=0)
-
-
-def extract_roi_from_ror(image, boundary_size):
-    """Given a 3D ROR and the boundary size, extract the ROI by removing the boundary.
-
-    Args:
-        image (ndarray): 3D numpy array with a shape of (num_img_slices, num_img_rows, num_img_cols)
-        boundary_size (list): Number of invalid pixels on each side of a 3D image. A list of 3 integer, [img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size].
-
-    Returns:
-        roi_image: 3D padded image with shape (num_img_slices-2*boundary_size[0], num_img_rows-2*boundary_size[1], num_img_cols-2*boundary_size[2]).
-    """
-    num_img_slices, num_img_rows, num_img_cols = image.shape
-    img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size = boundary_size
-    assert num_img_slices > 2 * img_slices_boundary_size and num_img_slices > 2 * img_slices_boundary_size and num_img_slices > 2 * img_slices_boundary_size, 'The shape of the roi image should be positive.'
-    return image[img_slices_boundary_size:-img_slices_boundary_size,
-                 img_rows_boundary_size:-img_rows_boundary_size,
-                 img_cols_boundary_size:-img_cols_boundary_size]
-
 
 def recon(sino, angles, dist_source_detector, magnification,
           geometry='cone',
@@ -475,13 +440,13 @@ def recon(sino, angles, dist_source_detector, magnification,
     if num_image_slices is None:
         _,_,num_image_slices = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
     
-    sinoparams = compute_sino_params(dist_source_detector, magnification,
+    sinoparams = create_sino_params_dict(dist_source_detector, magnification,
                                      num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
                                      det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
                                      rotation_offset=rotation_offset,
                                      delta_pixel_detector=delta_pixel_detector)
     
-    imgparams = auto_image_params(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
+    imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
     
     # make sure that weights do not contain negative entries
     # if weights is provided, and negative entry exists, then do not use the provided weights
@@ -627,7 +592,7 @@ def project(image, angles,
 
     num_views = len(angles)
 
-    sinoparams = compute_sino_params(dist_source_detector, magnification,
+    sinoparams = create_sino_params_dict(dist_source_detector, magnification,
                                      num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
                                      det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
                                      rotation_offset=rotation_offset,
@@ -635,7 +600,7 @@ def project(image, angles,
      
     (num_image_slices, num_image_rows, num_image_cols) = image.shape
     
-    imgparams = auto_image_params(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image)
+    imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image)
 
     hash_val = _utils.hash_params(angles, sinoparams, imgparams)
     sysmatrix_fname = _utils._gen_sysmatrix_fname(lib_path=lib_path, sysmatrix_name=hash_val[:__namelen_sysmatrix])

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -231,7 +231,7 @@ def auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_
 def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=1.0, image_slice_offset=0.0):
     """ Allocate imageparam parameters as required by certain C methods.
         Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
-        For detailed specifications of sinoparams, see cone3D.interface_cy_c
+        For detailed specifications of imageparams, see cone3D.interface_cy_c
     
     Args:
         num_image_rows (int): Integer number of rows in image region.


### PR DESCRIPTION
Hi all,

This is a 'hotfix' to my recent pull request that had some unfinished business.

Changes:

- update the cone3D.rst file and made some changes to the dosctrings. 
- remove deprecated methods extract_roi_from_roi, pad_roi2ror
- add a point-spread test file to the demo suite

I started to create a 'test' suite, but a test suite would need to access the 'demo_utils' module in order to run.  So, I have left 'debug_forward_proj.py' in the demo suite, knowing that it _should_ be divided out into its own suite that also has access to 'demo_utils'.

**Note that the multinode demo files still need to be updated and tested, since they previously relied on methods that are now deprecated.**