### PR TITLE
Laminography 1.1

### DIFF
--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -1,0 +1,161 @@
+import os
+import numpy as np
+import mbircone
+from demo_utils import plot_image, plot_gif
+
+# laminographic angle
+theta_degrees = 60
+
+# detector size
+num_det_rows = 128
+num_det_channels = 128
+
+# number of projection views
+num_views = 128
+
+# Phantom parameters
+num_slices_phantom = 16
+num_rows_phantom = 90
+num_cols_phantom = 90
+
+# begin experiment
+theta = theta_degrees * (np.pi/180)
+
+# projection angles will be uniformly spaced within the range [0, 2*pi).
+angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
+# qGGMRF recon parameters
+sharpness = 1.0                             # Controls regularization level of reconstruction by controling prior term weighting
+T = 0.1                                     # Controls edginess of reconstruction
+# convergence parameters
+stop_threshold = 0.005
+# display parameters
+vmin = 0.0
+vmax = 0.1
+
+# local path to save phantom, sinogram, and reconstruction images
+save_path = f'output/laminography_tests/'
+os.makedirs(save_path, exist_ok=True)
+
+print('Genrating 3D Shepp Logan phantom ...')
+
+phantom = mbircone.phantom.gen_lamino_sample_3d(num_rows_phantom, num_cols_phantom, num_slices_phantom)
+
+# Scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
+phantom = phantom/10.0
+
+# Compute ROR and ROI sizes
+(num_slices_ROR, num_rows_ROR, num_cols_ROR), boundary_size = mbircone.cone3D.compute_img_size(num_views, num_det_rows, num_det_channels, None, 1, geometry='lamino', theta=theta)
+
+#num_slices_ROI = num_slices_ROR - 2 * boundary_size[0]
+#num_rows_ROI = num_rows_ROR - 2 * boundary_size[1]
+#num_cols_ROI = num_cols_ROR - 2 * boundary_size[2]
+
+print('ROR shape is:', num_slices_ROR, num_rows_ROR, num_cols_ROR)
+#print('ROI shape is:', num_slices_ROI, num_rows_ROI, num_cols_ROI)
+print('phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
+
+#max_phantom_size =
+#if num_slices_phantom > num_slices_ROI or num_rows_phantom > num_rows_ROI or num_cols_phantom > num_cols_ROI:
+#    print('Warning, phantom size is too big for ROI shape.')
+
+# Pad phantom to ROR size:
+pad_slices = num_slices_ROR - num_slices_phantom
+pad_slices_L = pad_slices // 2
+pad_slices_R = pad_slices - pad_slices_L
+
+pad_rows = num_rows_ROR - num_rows_phantom
+pad_rows_L = pad_rows // 2
+pad_rows_R = pad_rows - pad_rows_L
+
+pad_cols = num_cols_ROR - num_cols_phantom
+pad_cols_L = pad_cols // 2
+pad_cols_R = pad_cols - pad_cols_L
+
+phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
+phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
+
+print('Padded ROR phantom shape = ', np.shape(phantom))
+
+#display_slice = phantom.shape[0] // 2
+#display_x = phantom.shape[1] // 2
+#display_y = phantom.shape[2] * 3// 4
+#plot_image(phantom[display_slice], title=f'phantom, axial slice', filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+#plot_image(phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}',
+#                     filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+#plot_image(phantom[:,:,display_y], title=f'phantom, sagittal slice {display_y}',
+#                     filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+#input("Press Enter")
+
+
+
+######################################################################################
+# Generate synthetic sinogram
+######################################################################################
+print('Generating synthetic sinogram ...')
+sino = mbircone.cone3D.project(phantom, angles, num_det_rows, num_det_channels, None, 1,
+                                geometry='lamino', theta=theta)
+print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
+
+
+######################################################################################
+# Perform 3D qGGMRF reconstruction
+######################################################################################
+print('Performing 3D qGGMRF reconstruction ...')
+recon = mbircone.cone3D.recon(sino, angles, None, 1, geometry='lamino', theta=theta, sharpness=sharpness, T = T, stop_threshold = stop_threshold, max_resolutions=0)
+print('recon shape = ', np.shape(recon))
+
+
+#####################################################################################
+# Generate phantom, synthetic sinogram, and reconstruction images
+#####################################################################################
+# sinogram images
+for view_idx in [0, num_views//4, num_views//2]:
+        view_angle = int(angles[view_idx]*180/np.pi)
+        plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle} ',
+                             filename=os.path.join(save_path, f'sino-shepp-logan-3D-view_angle{view_angle}.png'))
+
+display_phantom = phantom
+display_recon = recon
+
+
+#display_phantom = phantom[pad_slices_L:-pad_slices_R,pad_rows_L:-pad_rows_R,pad_cols_L:-pad_cols_R]
+#display_recon = recon[pad_slices_L:-pad_slices_R,pad_rows_L:-pad_rows_R,pad_cols_L:-pad_cols_R]
+
+display_error = np.abs(display_recon - display_phantom)
+print(f'normalized rms reconstruction error: {np.sqrt(np.mean(display_error**2))/np.sqrt(np.mean(display_phantom**2)):.3g}')
+
+
+
+# Set display indexes for phantom and recon images
+display_slice = display_recon.shape[0] // 2
+display_x = display_recon.shape[1] // 2
+display_y = display_recon.shape[2] // 2
+# phantom images
+plot_image(display_phantom[display_slice], title=f'phantom, axial slice {display_slice}',
+                     filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_phantom[display_slice], title=f'phantom, axial slice {display_slice}',
+                     filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}',
+                     filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_phantom[:,:,display_y], title=f'phantom, sagittal slice {display_y}',
+                     filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+# recon images
+plot_image(display_recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+                     filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
+plot_image(display_recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+                     filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_recon[:,display_x,:], title=f'qGGMRF recon, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
+                     filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_recon[:,:,display_y], title=f'qGGMRF recon, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
+                     filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
+# error images
+plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+                  filename=os.path.join(save_path, 'error_axial.png'), vmin=0, vmax=0.40)
+plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+                  filename=os.path.join(save_path, 'error_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_error[:,display_x,:], title=f'error image, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
+                  filename=os.path.join(save_path, 'error_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_error[:,:,display_y], title=f'error image, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
+                  filename=os.path.join(save_path, 'error_sagittal.png'), vmin=vmin, vmax=vmax)
+print(f"Images saved to {save_path}.")
+input("Press Enter")

--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -53,8 +53,8 @@ pad_cols_R = pad_cols_L
 pad_slices_L = num_slices_phantom * pad_factor
 pad_slices_R = pad_slices_L
 
-phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
-phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
+phantom = np.pad(phantom, [(0, 0), (pad_rows_L, pad_rows_R),(pad_cols_L, pad_cols_R)], mode='edge')
+phantom = np.pad(phantom, [(pad_slices_L, pad_slices_R), (0, 0), (0, 0)], mode='constant', constant_values=0.0)
 
 ######################################################################################
 # Generate synthetic sinogram
@@ -69,7 +69,7 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D qGGMRF reconstruction
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...')
-recon = mbircone.cone3D.recon(sino, angles, None, 1, geometry='lamino', theta=theta, sharpness=sharpness, T=T,
+recon = mbircone.cone3D.recon(sino, angles, None, None, geometry='lamino', theta=theta, sharpness=sharpness, T=T,
                               stop_threshold=stop_threshold, max_resolutions=0, num_image_rows=384,
                               num_image_cols=384, num_image_slices=32)
 print('recon shape = ', np.shape(recon))
@@ -111,9 +111,9 @@ plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice
            filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
 plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, Θ='+str(theta_degrees)+' degrees',
            filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(display_recon[:,display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[:, display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, Θ='+str(theta_degrees)+' degrees',
            filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
-plot_image(display_recon[:,:,display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[:, :, display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, Θ='+str(theta_degrees)+' degrees',
            filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
 
 print(f"Images saved to {save_path}.")

--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -24,8 +24,8 @@ theta = theta_degrees * (np.pi/180)
 # projection angles will be uniformly spaced within the range [0, 2*pi).
 angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
 # qGGMRF recon parameters
-sharpness = 1.0                             # Controls regularization level of reconstruction by controling prior term weighting
-T = 0.1                                     # Controls edginess of reconstruction
+sharpness = 1.0                     # Controls regularization level of reconstruction by controling prior term weighting
+T = 0.1                             # Controls edginess of reconstruction
 # convergence parameters
 stop_threshold = 0.005
 # display parameters
@@ -42,55 +42,26 @@ phantom = mbircone.phantom.gen_lamino_sample_3d(num_rows_phantom, num_cols_phant
 
 # Scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
 phantom = phantom/10.0
-
-# Compute ROR and ROI sizes
-#(num_slices_ROR, num_rows_ROR, num_cols_ROR), boundary_size = mbircone.cone3D.compute_img_size(num_views, num_det_rows, num_det_channels, None, 1, geometry='lamino', theta=theta)
-
-#num_slices_ROI = num_slices_ROR - 2 * boundary_size[0]
-#num_rows_ROI = num_rows_ROR - 2 * boundary_size[1]
-#num_cols_ROI = num_cols_ROR - 2 * boundary_size[2]
-
-#print('ROR shape is:', num_slices_ROR, num_rows_ROR, num_cols_ROR)
-#print('ROI shape is:', num_slices_ROI, num_rows_ROI, num_cols_ROI)
 print('Phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
 
 
-# Pad phantom to ROR size:
-#pad_slices = num_slices_ROR - num_slices_phantom
-#pad_slices_L = pad_slices // 2
-#pad_slices_R = pad_slices - pad_slices_L
-#
-#pad_rows = num_rows_ROR - num_rows_phantom
-#pad_rows_L = pad_rows // 2
-#pad_rows_R = pad_rows - pad_rows_L
-#
-#pad_cols = num_cols_ROR - num_cols_phantom
-#pad_cols_L = pad_cols // 2
-#pad_cols_R = pad_cols - pad_cols_L
-#
-#phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
-#phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
+pad_factor = 2
+pad_rows_L = num_rows_phantom * pad_factor
+pad_rows_R = pad_rows_L
+pad_cols_L = num_cols_phantom * pad_factor
+pad_cols_R = pad_cols_L
+pad_slices_L = num_slices_phantom * pad_factor
+pad_slices_R = pad_slices_L
 
-#print('Padded ROR phantom shape = ', np.shape(phantom))
-
-#display_slice = phantom.shape[0] // 2
-#display_x = phantom.shape[1] // 2
-#display_y = phantom.shape[2] * 3// 4
-#plot_image(phantom[display_slice], title=f'phantom, axial slice', filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
-#plot_image(phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}',
-#                     filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
-#plot_image(phantom[:,:,display_y], title=f'phantom, sagittal slice {display_y}',
-#                     filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
-#input("Press Enter")
-
-
+phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
+phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
 
 ######################################################################################
 # Generate synthetic sinogram
 ######################################################################################
 print('Generating synthetic sinogram ...')
 sino = mbircone.cone3D.project(phantom, angles, num_det_rows, num_det_channels, None, 1,
-                                geometry='lamino', theta=theta)
+                               geometry='lamino', theta=theta)
 print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
 
 
@@ -98,7 +69,9 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D qGGMRF reconstruction
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...')
-recon = mbircone.cone3D.recon(sino, angles, None, 1, geometry='lamino', theta=theta, sharpness=sharpness, T = T, stop_threshold = stop_threshold, max_resolutions=0)
+recon = mbircone.cone3D.recon(sino, angles, None, 1, geometry='lamino', theta=theta, sharpness=sharpness, T=T,
+                              stop_threshold=stop_threshold, max_resolutions=0, num_image_rows=384,
+                              num_image_cols=384, num_image_slices=32)
 print('recon shape = ', np.shape(recon))
 
 
@@ -109,13 +82,11 @@ print('recon shape = ', np.shape(recon))
 for view_idx in [0, num_views//4, num_views//2]:
         view_angle = int(angles[view_idx]*180/np.pi)
         plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle} ',
-                             filename=os.path.join(save_path, f'sino-shepp-logan-3D-view_angle{view_angle}.png'))
+                   filename=os.path.join(save_path, f'sino-shepp-logan-3D-view_angle{view_angle}.png'),
+                   vmin=0.0, vmax=2.0)
 
 display_phantom = phantom
 display_recon = recon
-
-#display_error = np.abs(display_recon - display_phantom)
-#print(f'normalized rms reconstruction error: {np.sqrt(np.mean(display_error**2))/np.sqrt(np.mean(display_phantom**2)):.3g}')
 
 # Set display indexes for phantom and recon images
 display_slice_image = display_phantom.shape[0] // 2
@@ -128,30 +99,22 @@ display_y_recon = display_recon.shape[2] // 2
 
 # phantom images
 plot_image(display_phantom[display_slice_image], title=f'phantom, axial slice {display_slice_image}',
-                     filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
 plot_image(display_phantom[display_slice_image], title=f'phantom, axial slice {display_slice_image}',
-                     filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
 plot_image(display_phantom[:,display_x_image,:], title=f'phantom, coronal slice {display_x_image}',
-                     filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
 plot_image(display_phantom[:,:,display_y_image], title=f'phantom, sagittal slice {display_y_image}',
-                     filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
 # recon images
 plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, Θ='+str(theta_degrees)+' degrees',
-                     filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
+           filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
 plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, Θ='+str(theta_degrees)+' degrees',
-                     filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
 plot_image(display_recon[:,display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, Θ='+str(theta_degrees)+' degrees',
-                     filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
 plot_image(display_recon[:,:,display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, Θ='+str(theta_degrees)+' degrees',
-                     filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
-# error images
-#plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
-#                  filename=os.path.join(save_path, 'error_axial.png'), vmin=0, vmax=0.40)
-#plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
-#                  filename=os.path.join(save_path, 'error_axial.png'), vmin=vmin, vmax=vmax)
-#plot_image(display_error[:,display_x,:], title=f'error image, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
-#                  filename=os.path.join(save_path, 'error_coronal.png'), vmin=vmin, vmax=vmax)
-#plot_image(display_error[:,:,display_y], title=f'error image, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
-#                  filename=os.path.join(save_path, 'error_sagittal.png'), vmin=vmin, vmax=vmax)
+           filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
+
 print(f"Images saved to {save_path}.")
 input("Press Enter")

--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -44,37 +44,34 @@ phantom = mbircone.phantom.gen_lamino_sample_3d(num_rows_phantom, num_cols_phant
 phantom = phantom/10.0
 
 # Compute ROR and ROI sizes
-(num_slices_ROR, num_rows_ROR, num_cols_ROR), boundary_size = mbircone.cone3D.compute_img_size(num_views, num_det_rows, num_det_channels, None, 1, geometry='lamino', theta=theta)
+#(num_slices_ROR, num_rows_ROR, num_cols_ROR), boundary_size = mbircone.cone3D.compute_img_size(num_views, num_det_rows, num_det_channels, None, 1, geometry='lamino', theta=theta)
 
 #num_slices_ROI = num_slices_ROR - 2 * boundary_size[0]
 #num_rows_ROI = num_rows_ROR - 2 * boundary_size[1]
 #num_cols_ROI = num_cols_ROR - 2 * boundary_size[2]
 
-print('ROR shape is:', num_slices_ROR, num_rows_ROR, num_cols_ROR)
+#print('ROR shape is:', num_slices_ROR, num_rows_ROR, num_cols_ROR)
 #print('ROI shape is:', num_slices_ROI, num_rows_ROI, num_cols_ROI)
-print('phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
+print('Phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
 
-#max_phantom_size =
-#if num_slices_phantom > num_slices_ROI or num_rows_phantom > num_rows_ROI or num_cols_phantom > num_cols_ROI:
-#    print('Warning, phantom size is too big for ROI shape.')
 
 # Pad phantom to ROR size:
-pad_slices = num_slices_ROR - num_slices_phantom
-pad_slices_L = pad_slices // 2
-pad_slices_R = pad_slices - pad_slices_L
+#pad_slices = num_slices_ROR - num_slices_phantom
+#pad_slices_L = pad_slices // 2
+#pad_slices_R = pad_slices - pad_slices_L
+#
+#pad_rows = num_rows_ROR - num_rows_phantom
+#pad_rows_L = pad_rows // 2
+#pad_rows_R = pad_rows - pad_rows_L
+#
+#pad_cols = num_cols_ROR - num_cols_phantom
+#pad_cols_L = pad_cols // 2
+#pad_cols_R = pad_cols - pad_cols_L
+#
+#phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
+#phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
 
-pad_rows = num_rows_ROR - num_rows_phantom
-pad_rows_L = pad_rows // 2
-pad_rows_R = pad_rows - pad_rows_L
-
-pad_cols = num_cols_ROR - num_cols_phantom
-pad_cols_L = pad_cols // 2
-pad_cols_R = pad_cols - pad_cols_L
-
-phantom = np.pad(phantom, [(0,0),(pad_rows_L,pad_rows_R),(pad_cols_L,pad_cols_R)], mode='edge')
-phantom = np.pad(phantom, [(pad_slices_L,pad_slices_R), (0,0), (0,0)], mode='constant', constant_values=0.0)
-
-print('Padded ROR phantom shape = ', np.shape(phantom))
+#print('Padded ROR phantom shape = ', np.shape(phantom))
 
 #display_slice = phantom.shape[0] // 2
 #display_x = phantom.shape[1] // 2
@@ -117,45 +114,44 @@ for view_idx in [0, num_views//4, num_views//2]:
 display_phantom = phantom
 display_recon = recon
 
-
-#display_phantom = phantom[pad_slices_L:-pad_slices_R,pad_rows_L:-pad_rows_R,pad_cols_L:-pad_cols_R]
-#display_recon = recon[pad_slices_L:-pad_slices_R,pad_rows_L:-pad_rows_R,pad_cols_L:-pad_cols_R]
-
-display_error = np.abs(display_recon - display_phantom)
-print(f'normalized rms reconstruction error: {np.sqrt(np.mean(display_error**2))/np.sqrt(np.mean(display_phantom**2)):.3g}')
-
-
+#display_error = np.abs(display_recon - display_phantom)
+#print(f'normalized rms reconstruction error: {np.sqrt(np.mean(display_error**2))/np.sqrt(np.mean(display_phantom**2)):.3g}')
 
 # Set display indexes for phantom and recon images
-display_slice = display_recon.shape[0] // 2
-display_x = display_recon.shape[1] // 2
-display_y = display_recon.shape[2] // 2
+display_slice_image = display_phantom.shape[0] // 2
+display_x_image = display_phantom.shape[1] // 2
+display_y_image = display_phantom.shape[2] // 2
+
+display_slice_recon = display_recon.shape[0] // 2
+display_x_recon = display_recon.shape[1] // 2
+display_y_recon = display_recon.shape[2] // 2
+
 # phantom images
-plot_image(display_phantom[display_slice], title=f'phantom, axial slice {display_slice}',
+plot_image(display_phantom[display_slice_image], title=f'phantom, axial slice {display_slice_image}',
                      filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(display_phantom[display_slice], title=f'phantom, axial slice {display_slice}',
+plot_image(display_phantom[display_slice_image], title=f'phantom, axial slice {display_slice_image}',
                      filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(display_phantom[:,display_x,:], title=f'phantom, coronal slice {display_x}',
+plot_image(display_phantom[:,display_x_image,:], title=f'phantom, coronal slice {display_x_image}',
                      filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
-plot_image(display_phantom[:,:,display_y], title=f'phantom, sagittal slice {display_y}',
+plot_image(display_phantom[:,:,display_y_image], title=f'phantom, sagittal slice {display_y_image}',
                      filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
 # recon images
-plot_image(display_recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, Θ='+str(theta_degrees)+' degrees',
                      filename=os.path.join(save_path, 'recon_axial.png'), vmin=0, vmax=0.40)
-plot_image(display_recon[display_slice], title=f'qGGMRF recon, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, Θ='+str(theta_degrees)+' degrees',
                      filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(display_recon[:,display_x,:], title=f'qGGMRF recon, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[:,display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, Θ='+str(theta_degrees)+' degrees',
                      filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
-plot_image(display_recon[:,:,display_y], title=f'qGGMRF recon, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
+plot_image(display_recon[:,:,display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, Θ='+str(theta_degrees)+' degrees',
                      filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
 # error images
-plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
-                  filename=os.path.join(save_path, 'error_axial.png'), vmin=0, vmax=0.40)
-plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
-                  filename=os.path.join(save_path, 'error_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(display_error[:,display_x,:], title=f'error image, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
-                  filename=os.path.join(save_path, 'error_coronal.png'), vmin=vmin, vmax=vmax)
-plot_image(display_error[:,:,display_y], title=f'error image, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
-                  filename=os.path.join(save_path, 'error_sagittal.png'), vmin=vmin, vmax=vmax)
+#plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+#                  filename=os.path.join(save_path, 'error_axial.png'), vmin=0, vmax=0.40)
+#plot_image(display_error[display_slice], title=f'error image, axial slice {display_slice}, Θ='+str(theta_degrees)+' degrees',
+#                  filename=os.path.join(save_path, 'error_axial.png'), vmin=vmin, vmax=vmax)
+#plot_image(display_error[:,display_x,:], title=f'error image, coronal slice {display_x}, Θ='+str(theta_degrees)+' degrees',
+#                  filename=os.path.join(save_path, 'error_coronal.png'), vmin=vmin, vmax=vmax)
+#plot_image(display_error[:,:,display_y], title=f'error image, sagittal slice {display_y}, Θ='+str(theta_degrees)+' degrees',
+#                  filename=os.path.join(save_path, 'error_sagittal.png'), vmin=vmin, vmax=vmax)
 print(f"Images saved to {save_path}.")
 input("Press Enter")

--- a/docs/source/cone3D.rst
+++ b/docs/source/cone3D.rst
@@ -9,6 +9,8 @@ mbircone.cone3D
 
    .. autosummary::
 
+      recon
+      project
       auto_image_size
       auto_sigma_p
       auto_sigma_x
@@ -18,5 +20,3 @@ mbircone.cone3D
       create_sino_params_dict
       create_image_params_dict_lamino
       create_sino_params_dict_lamino
-      project
-      recon

--- a/docs/source/cone3D.rst
+++ b/docs/source/cone3D.rst
@@ -1,7 +1,7 @@
 mbircone.cone3D
 ---------------
 .. automodule:: mbircone.cone3D
-   :members: auto_image_size, auto_sigma_x, auto_sigma_p, auto_sigma_y, calc_weights, create_image_params_dict, create_sino_params_dict, project, recon
+   :members: auto_image_size, auto_sigma_x, auto_sigma_p, auto_sigma_y, calc_weights, create_image_params_dict, create_sino_params_dict, create_image_params_dict_lamino, create_sino_params_dict_lamino, project, recon
    :undoc-members:    
    :show-inheritance:
 
@@ -16,5 +16,7 @@ mbircone.cone3D
       calc_weights
       create_image_params_dict
       create_sino_params_dict
+      create_image_params_dict_lamino
+      create_sino_params_dict_lamino
       project
       recon

--- a/docs/source/phantom.rst
+++ b/docs/source/phantom.rst
@@ -1,7 +1,7 @@
 mbircone.phantom
 ----------------
 .. automodule:: mbircone.phantom
-   :members: gen_shepp_logan, gen_shepp_logan_3d, gen_microscopy_sample, gen_microscopy_sample_3d 
+   :members: gen_shepp_logan, gen_shepp_logan_3d, gen_microscopy_sample, gen_microscopy_sample_3d, gen_lamino_sample_3d
    :undoc-members:
    :show-inheritance:
 
@@ -12,5 +12,6 @@ mbircone.phantom
       gen_shepp_logan
       gen_shepp_logan_3d
       gen_microscopy_sample
-      gen_microscopy_sample_3d 
+      gen_microscopy_sample_3d
+      gen_lamino_sample_3d
 

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -391,7 +391,7 @@ def create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
 
 
 def create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
-                                  delta_pixel_image=1.0, image_slice_offset=0.0):
+                                    delta_pixel_image=1.0, image_slice_offset=0.0):
     """ Allocate imageparams parameters as required by certain C methods.
         Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
         All geometry specifications (i.e. function arguments) are given in laminography coordinates.
@@ -462,7 +462,7 @@ def recon(sino, angles, dist_source_detector, magnification,
         
         geometry (string, optional): [Default='cone'] This can be 'cone' or 'lamino'.
             If geometry=='cone', runs a standard cone-beam reconstruction.
-            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset.
+            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, det_row_offset, rotation_offset.
         
         weights (ndarray, optional): [Default=None] 3D weights array with same shape as sino.
         weight_type (string, optional): [Default='unweighted'] Type of noise model used for data.
@@ -581,8 +581,8 @@ def recon(sino, angles, dist_source_detector, magnification,
                                                     delta_pixel_detector=delta_pixel_detector)
 
         imgparams = create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
-                                                  delta_pixel_image=delta_pixel_image,
-                                                  image_slice_offset=image_slice_offset)
+                                                    delta_pixel_image=delta_pixel_image,
+                                                    image_slice_offset=image_slice_offset)
     else:
         raise Exception("geometry: undefined geometry {}".format(geometry))
 
@@ -706,7 +706,7 @@ def project(image, angles,
 
         geometry (string, optional): [Default='cone'] This can be 'cone' or 'lamino'.
             If geometry=='cone', runs a standard cone-beam reconstruction.
-            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset.
+            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, det_row_offset, rotation_offset.
 
         det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a row.
         det_row_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a column.
@@ -759,7 +759,7 @@ def project(image, angles,
         (num_image_slices, num_image_rows, num_image_cols) = image.shape
 
         imgparams = create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
-                                                  delta_pixel_image=delta_pixel_image)
+                                                    delta_pixel_image=delta_pixel_image)
     else:
         raise Exception("geometry: undefined geometry {}".format(geometry))
 

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -381,7 +381,7 @@ def create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
 
   return sinoparams
 
-def create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=None):
+def create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=1.0, image_slice_offset=0.0):
 
   """ Compute image parameters that specify coordinates and bounds relating to the image.
     For detailed specifications of imgparams, see cone3D.interface_cy_c
@@ -399,74 +399,19 @@ def create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=None):
     Dictionary containing image parameters as required by the Cython code
   """
 
-  # Step 1: Calculate ROI and ROR shape
+  dist_source_detector = -sinoparams['u_s']
 
-  # Set voxel dimensions
-  # assert delta_pixel_image != None
-  # (it is actually never None because of code structure)
-  s = delta_pixel_image
-  ell = delta_pixel_image
-
-  # Retrieve detector dimensions from sinoparams
-  N_C = sinoparams['N_dv']
-  T_C = sinoparams['Delta_dv']
-  N_R = sinoparams['N_dw']
-  T_R = sinoparams['Delta_dw']
-
-  # Calculate height of a single cone
-  # = half the height of the double-cone
-  # = half the image height
-  H = (N_R * T_R) / (2 * np.sin(theta))
-  
-  # Set radius of ROI
-  # Region with measured pixels is intersection of
-  # double-cone and a cylinder.
-  # r_cyl = Radius of cylinder
-  # max_rad prevents radius from becoming large,
-  # which might flatten the image. This code must be
-  # changed if user is given control over ROI
-  y_0 = sinoparams['v_d0'] + (N_C * T_C / 2)
-  r_cyl = (N_C * T_C / 2) - np.abs(y_0)
-  max_rad = (N_R * T_R / 2)
-  r_roi = min(r_cyl,max_rad)
-
-  # Set height of ROI
-  h = H - (r_roi / np.tan(theta))
-  
-  ROR_SHAPE = 'TIGHT'
-  
-  if ROR_SHAPE == 'TIGHT':
-      # Set to the geometrically correct radius
-      # See laminography slides for visual explanation
-      # This does not give good results and should not be used
-      R_cyl_1 = (N_C * T_C / 2) - np.abs(y_0)
-      R_cyl_2 = (N_R * T_R) / (2 * np.cos(theta))
-      R_ROR = min(R_cyl_1, R_cyl_2)
-  elif ROR_SHAPE == 'BROAD':
-      # Set to experimentally correct radius
-      # See laminography slides for visual explanation
-      r = r_roi
-      w = 2 * h
-      R_ROR = r + w * np.tan(theta)
-
-  # Step 2: Assign Parameters
-  
   imgparams = dict()
+  imgparams['N_x'] = num_image_rows
+  imgparams['N_y'] = num_image_cols
+  imgparams['N_z'] = num_image_slices
 
-  # Corner of bottom-left voxel (= coordinate of center minus 1/2 voxel width)
-  imgparams['x_0'] = - R_ROR - s / 2
-  imgparams['y_0'] = imgparams['x_0']
-  # z_0 = - H - D/tan(theta)
-  # w_d0 = - D/tan(theta) - (N_R * T_R / 2)
-  imgparams['z_0'] = - H + sinoparams['w_d0'] + (N_R * T_R / 2)
-
-  # Voxel count in x,y,z, directions
-  imgparams['N_x'] = int(2 * np.ceil(R_ROR / s) + 1)
-  imgparams['N_y'] = imgparams['N_x']
-  imgparams['N_z'] = int(2 * np.ceil(H / ell) + 1)
-
-  imgparams['Delta_xy'] = s
-  imgparams['Delta_z'] = ell
+  imgparams['Delta_xy'] = delta_pixel_image
+  imgparams['Delta_z'] = delta_pixel_image
+  
+  imgparams['x_0'] = -imgparams['N_x']*imgparams['Delta_xy']/2.0
+  imgparams['y_0'] = -imgparams['N_y']*imgparams['Delta_xy']/2.0
+  imgparams['z_0'] = -imgparams['N_z']*imgparams['Delta_z']/2.0 - image_slice_offset - (dist_source_detector / math.tan(theta))
   
   # Find coordinates of roi within the voxel image
   imgparams['j_xstart_roi'] = -1
@@ -482,74 +427,6 @@ def create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=None):
   imgparams['N_z_roi'] = -1
 
   return imgparams
-
-# TO DELETE LATER ---------------------- TO DELETE LATER
-def compute_img_size(num_views, num_det_rows, num_det_channels,
-                 dist_source_detector,
-                 magnification,
-                 channel_offset=0.0, row_offset=0.0, rotation_offset=0.0,
-                 delta_pixel_detector=1.0, delta_pixel_image=None, ror_radius=None,
-                 geometry='cone', theta=math.pi/2):
-  """Compute size of the reconstructed image given the geometric parameters.
-  Args:
-      num_views (int): Number of views in sinogram data
-      num_det_rows (int): Number of rows in sinogram data
-      num_det_channels (int): Number of channels in sinogram data
-      dist_source_detector (float): Distance between the X-ray source and the detector in units of ALU
-      magnification (float): Magnification of the cone-beam geometry defined as (source to detector distance)/(source to center-of-rotation distance).
-      channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a row.
-      row_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a column.
-      rotation_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from source-detector line to axis of rotation in the object space.
-          This is normally set to zero.
-      delta_pixel_detector (float, optional): [Default=1.0] Scalar value of detector pixel spacing in :math:`ALU`.
-      delta_pixel_image (float, optional): [Default=None] Scalar value of image pixel spacing in :math:`ALU`.
-          If None, automatically set to delta_pixel_detector/magnification
-      ror_radius (float, optional): [Default=None] Scalar value of radius of reconstruction in :math:`ALU`.
-          If None, automatically set.
-          Pixels outside the radius ror_radius in the :math:`(x,y)` plane are disregarded in the reconstruction.
-          
-      geometry (string, optional): This can be 'cone' or 'lamino'.
-          If geometry=='cone', computes image size for a cone beam reconstruction.
-          If geometry=='lamino', computes image size for laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset.
-      theta (float, optional): Laminographic angle, equal to pi/2 - grazing angle. Ignored if geometry=='cone'.
-  Returns:
-      Information about the image size.
-      - **ROR (list)**: Region of reconstruction that specifies the size of the reconstructed image. A list of 3 integer, [num_img_slices, num_img_rows, num_img_cols]. However, the valid region of interest (ROI) is a subset of ROR.
-      - **boundary_size (list)**: Number of invalid pixels on each side of a 3D image. A list of 3 integer, [img_slices_boundary_size, img_rows_boundary_size, img_cols_boundary_size]. The function `cone3D.extract_roi_from_ror` can be used to extract ROI from the full ROR.
-  """
-
-  # Automatically set delta_pixel_image.
-  if geometry=='lamino':
-      magnification = 1
-  if delta_pixel_image is None:
-      delta_pixel_image = delta_pixel_detector / magnification
-
-  if geometry=='cone':
-      # Calculate parameter dictionary with given input.
-      sinoparams = create_sino_params_dict(dist_source_detector, magnification,
-                                       num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
-                                       channel_offset=channel_offset, row_offset=row_offset,
-                                       rotation_offset=rotation_offset,
-                                       delta_pixel_detector=delta_pixel_detector)
-
-      imgparams = create_img_params_dict(sinoparams, delta_pixel_image=delta_pixel_image, ror_radius=ror_radius)
-  elif geometry=='lamino':
-      sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
-                                     theta,
-                                     det_channel_offset=channel_offset,
-                                     delta_pixel_detector=delta_pixel_detector)
-
-      imgparams = create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=delta_pixel_image)
-  else:
-      raise Exception("geometry: undefined geometry {}".format(geometry))
-
-  # Summarize Information about the image size.
-  ROR = [imgparams['N_z'], imgparams['N_x'], imgparams['N_y']]
-  boundary_size = [max(imgparams['j_zstart_roi'], imgparams['N_z']-1-imgparams['j_zstop_roi']), imgparams['j_xstart_roi'], imgparams['j_ystart_roi']]
-
-  return ROR, boundary_size
-# TO DELETE LATER ---------------------- TO DELETE LATER
-
 
 
 def recon(sino, angles, dist_source_detector, magnification,
@@ -663,15 +540,14 @@ def recon(sino, angles, dist_source_detector, magnification,
     if delta_pixel_image is None:
         delta_pixel_image = delta_pixel_detector/magnification
         
+    if num_image_rows is None:
+        num_image_rows,_,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
+    if num_image_cols is None:
+        _,num_image_cols,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
+    if num_image_slices is None:
+        _,_,num_image_slices = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
+        
     if geometry=='cone':
-    
-      if num_image_rows is None:
-          num_image_rows,_,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
-      if num_image_cols is None:
-          _,num_image_cols,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
-      if num_image_slices is None:
-          _,_,num_image_slices = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
-    
       sinoparams = create_sino_params_dict(dist_source_detector, magnification,
                                        num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
                                        det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
@@ -679,15 +555,13 @@ def recon(sino, angles, dist_source_detector, magnification,
                                        delta_pixel_detector=delta_pixel_detector)
       
       imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
-      
     elif geometry=='lamino':
-    
       sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
                                      theta,
                                      det_channel_offset=det_channel_offset,
                                      delta_pixel_detector=delta_pixel_detector)
-      imgparams = create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=delta_pixel_image)
-      
+                                     
+      imgparams = create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
     else:
       raise Exception("geometry: undefined geometry {}".format(geometry))
     
@@ -852,8 +726,10 @@ def project(image, angles,
                                      theta,
                                      det_channel_offset=det_channel_offset,
                                      delta_pixel_detector=delta_pixel_detector)
+      
+      (num_image_slices, num_image_rows, num_image_cols) = image.shape
 
-      imgparams = create_img_params_dict_lamino(sinoparams, theta, delta_pixel_image=delta_pixel_image)
+      imgparams = create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=delta_pixel_image)
     else:
       raise Exception("geometry: undefined geometry {}".format(geometry))
 
@@ -873,11 +749,6 @@ def project(image, angles,
     settings['sinoparams'] = sinoparams
     settings['sysmatrix_fname'] = sysmatrix_fname
     settings['num_threads'] = num_threads
-
-    print("stuff")
-    
-    print(sinoparams)
-    print(imgparams)
     
     proj = ci.project(image, settings)
     return proj

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -12,6 +12,7 @@ import mbircone._utils as _utils
 __lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
 __namelen_sysmatrix = 20
 
+
 def _sino_indicator(sino):
     """Compute a binary function that indicates the region of sinogram support.
 
@@ -84,7 +85,7 @@ def calc_weights(sino, weight_type):
     return weights
 
 
-def auto_max_resolutions(init_image) :
+def auto_max_resolutions(init_image):
     """Compute the automatic value of ``max_resolutions`` for use in MBIR reconstruction.
 
     Args:
@@ -95,7 +96,7 @@ def auto_max_resolutions(init_image) :
     # Default value of max_resolutions
     max_resolutions = 2
     if isinstance(init_image, np.ndarray) and (init_image.ndim == 3):
-        #print('Init image present. Setting max_resolutions = 0.')
+        # print('Init image present. Setting max_resolutions = 0.')
         max_resolutions = 0
 
     return max_resolutions
@@ -159,18 +160,20 @@ def auto_sigma_prior(sino, magnification, delta_pixel_detector=1.0, sharpness=0.
     Returns:
         float: Automatic value of regularization parameter.
     """
-    
+
     num_det_channels = sino.shape[-1]
 
     # Compute indicator function for sinogram support
     sino_indicator = _sino_indicator(sino)
 
     # Compute a typical image value by dividing average sinogram value by a typical projection path length
-    typical_img_value = np.average(sino, weights=sino_indicator) / (num_det_channels * delta_pixel_detector / magnification)
+    typical_img_value = np.average(sino, weights=sino_indicator) / (
+                num_det_channels * delta_pixel_detector / magnification)
 
     # Compute sigma_x as a fraction of the typical image value
     sigma_prior = (2 ** sharpness) * typical_img_value
     return sigma_prior
+
 
 def auto_sigma_x(sino, magnification, delta_pixel_detector=1.0, sharpness=0.0):
     """Compute the automatic value of ``sigma_x`` for use in MBIR reconstruction.
@@ -190,7 +193,7 @@ def auto_sigma_x(sino, magnification, delta_pixel_detector=1.0, sharpness=0.0):
     return 0.2 * auto_sigma_prior(sino, magnification, delta_pixel_detector, sharpness)
 
 
-def auto_sigma_p(sino, magnification, delta_pixel_detector = 1.0, sharpness = 0.0 ):
+def auto_sigma_p(sino, magnification, delta_pixel_detector=1.0, sharpness=0.0):
     """Compute the automatic value of ``sigma_p`` for use in proximal map estimation.
 
     Args:
@@ -203,8 +206,9 @@ def auto_sigma_p(sino, magnification, delta_pixel_detector = 1.0, sharpness = 0.
     Returns:
         float: Automatic value of regularization parameter.
     """
-    
+
     return 2.0 * auto_sigma_prior(sino, magnification, delta_pixel_detector, sharpness)
+
 
 def auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification):
     """Compute the automatic image size for use in recon.
@@ -221,17 +225,18 @@ def auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_
         (int, 3-tuple): Default values for num_image_rows, num_image_cols, num_image_slices for the inputted image measurements.
         
     """
-    
-    num_image_rows = int(np.round( num_det_channels*( (delta_pixel_detector/delta_pixel_image)/magnification ) ))
+
+    num_image_rows = int(np.round(num_det_channels * ((delta_pixel_detector / delta_pixel_image) / magnification)))
     num_image_cols = num_image_rows
-    num_image_slices = int(np.round( num_det_rows*( (delta_pixel_detector/delta_pixel_image)/magnification ) ))
-    
-    return (num_image_rows, num_image_cols, num_image_slices)
+    num_image_slices = int(np.round(num_det_rows * ((delta_pixel_detector / delta_pixel_image) / magnification)))
+
+    return num_image_rows, num_image_cols, num_image_slices
+
 
 def create_sino_params_dict(dist_source_detector, magnification,
-                        num_views, num_det_rows, num_det_channels,
-                        det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
-                        delta_pixel_detector=1.0):
+                            num_views, num_det_rows, num_det_channels,
+                            det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
+                            delta_pixel_detector=1.0):
     """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram.
         For detailed specifications of sinoparams, see cone3D.interface_cy_c
     
@@ -279,8 +284,10 @@ def create_sino_params_dict(dist_source_detector, magnification,
     sinoparams['weightScaler_value'] = -1
 
     return sinoparams
-    
-def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=1.0, image_slice_offset=0.0):
+
+
+def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=1.0,
+                             image_slice_offset=0.0):
     """ Allocate imageparam parameters as required by certain C methods.
         Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
         For detailed specifications of imageparams, see cone3D.interface_cy_c
@@ -304,12 +311,12 @@ def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, d
     imgparams['Delta_xy'] = delta_pixel_image
     imgparams['Delta_z'] = delta_pixel_image
 
-    imgparams['x_0'] = -imgparams['N_x']*imgparams['Delta_xy']/2.0
-    imgparams['y_0'] = -imgparams['N_y']*imgparams['Delta_xy']/2.0
-    imgparams['z_0'] = -imgparams['N_z']*imgparams['Delta_z']/2.0 - image_slice_offset
-        
+    imgparams['x_0'] = -imgparams['N_x'] * imgparams['Delta_xy'] / 2.0
+    imgparams['y_0'] = -imgparams['N_y'] * imgparams['Delta_xy'] / 2.0
+    imgparams['z_0'] = -imgparams['N_z'] * imgparams['Delta_z'] / 2.0 - image_slice_offset
+
     # depreciated parameters
-        
+
     imgparams['j_xstart_roi'] = -1
     imgparams['j_ystart_roi'] = -1
 
@@ -325,108 +332,113 @@ def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, d
 
     return imgparams
 
+
 def create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
-                  theta,
-                  det_channel_offset=0.0,
-                  delta_pixel_detector=1.0):
-                  
-  """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram
-      Function signatures are in laminogram coordinates, output corresponds to sinogram.
-      For detailed specifications of sinoparams, see cone3D.interface_cy_c
+                                   theta,
+                                   det_channel_offset=0.0,
+                                   delta_pixel_detector=1.0):
+    """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram
+        Function signatures are in laminogram coordinates, output corresponds to sinogram.
+        All geometry specifications (i.e. function arguments) are given in laminography coordinates.
+        For detailed specifications of sinoparams, see cone3D.interface_cy_c
   
-  Args:
-      num_views (int): Number of views in laminogram data
-      num_det_rows (int): Number of rows in laminogram data
-      num_det_channels (int): Number of channels in laminogram data
-      
-      theta (float): Laminographic angle; pi/2 - grazing angle
-      
-      det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the "projected axis of rotation" along a row.
-      delta_pixel_detector (float, optional): [Default=1.0] Scalar value of detector pixel spacing in :math:`ALU`.
-      
-  Returns:
-      Dictionary containing sino parameters as required by the Cython code
-  """
+    Args:
+        num_views (int): Number of views in laminogram data
+        num_det_rows (int): Number of rows in laminogram data
+        num_det_channels (int): Number of channels in laminogram data
 
-  # This needs to be large
-  dist_factor = 500
-  dist_source_detector = (dist_factor) * (delta_pixel_detector) * max(num_det_channels, num_det_rows)**2
+        theta (float): Laminographic angle; pi/2 - grazing angle
 
-  sinoparams = dict()
-  sinoparams['N_dv'] = num_det_channels
-  sinoparams['N_dw'] = num_det_rows
-  sinoparams['N_beta'] = num_views
-  sinoparams['Delta_dv'] = delta_pixel_detector
-  sinoparams['Delta_dw'] = delta_pixel_detector / math.sin(theta)
-  sinoparams['u_s'] = - dist_source_detector
-  sinoparams['u_r'] = 0
-  sinoparams['v_r'] = 0
-  sinoparams['u_d0'] = 0
+        det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the "projected axis of rotation" along a row.
+        delta_pixel_detector (float, optional): [Default=1.0] Scalar value of detector pixel spacing in :math:`ALU`.
 
-  dist_dv_to_detector_corner_from_detector_center = - sinoparams['N_dv'] * sinoparams['Delta_dv'] / 2
-  dist_dw_to_detector_corner_from_detector_center = - sinoparams['N_dw'] * sinoparams['Delta_dw'] / 2
+    Returns:
+        Dictionary containing sino parameters as required by the Cython code
+    """
 
-  # Real geometry effect
-  dist_dv_to_detector_center_from_source_detector_line = - det_channel_offset
-  # Set artificially to create angle
-  dist_dw_to_detector_center_from_source_detector_line = - dist_source_detector / math.tan(theta)
+    # Place source at a large distance with respect to detector size.
+    dist_factor = 500
+    dist_source_detector = dist_factor * delta_pixel_detector * max(num_det_channels, num_det_rows) ** 2
 
-  # Corner of detector from source-detector-line
-  sinoparams[
-      'v_d0'] = dist_dv_to_detector_corner_from_detector_center + dist_dv_to_detector_center_from_source_detector_line
-  sinoparams[
-      'w_d0'] = dist_dw_to_detector_corner_from_detector_center + dist_dw_to_detector_center_from_source_detector_line
+    sinoparams = dict()
+    sinoparams['N_dv'] = num_det_channels
+    sinoparams['N_dw'] = num_det_rows
+    sinoparams['N_beta'] = num_views
+    sinoparams['Delta_dv'] = delta_pixel_detector
+    sinoparams['Delta_dw'] = delta_pixel_detector / math.sin(theta)
+    sinoparams['u_s'] = - dist_source_detector
+    sinoparams['u_r'] = 0
+    sinoparams['v_r'] = 0
+    sinoparams['u_d0'] = 0
 
-  sinoparams['weightScaler_value'] = -1
+    dist_dv_to_detector_corner_from_detector_center = - sinoparams['N_dv'] * sinoparams['Delta_dv'] / 2
+    dist_dw_to_detector_corner_from_detector_center = - sinoparams['N_dw'] * sinoparams['Delta_dw'] / 2
 
-  return sinoparams
+    # Real geometry effect
+    dist_dv_to_detector_center_from_source_detector_line = - det_channel_offset
+    # Set artificially to create angle
+    dist_dw_to_detector_center_from_source_detector_line = - dist_source_detector / math.tan(theta)
 
-def create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=1.0, image_slice_offset=0.0):
+    # Corner of detector from source-detector-line
+    sinoparams[
+        'v_d0'] = dist_dv_to_detector_corner_from_detector_center + dist_dv_to_detector_center_from_source_detector_line
+    sinoparams[
+        'w_d0'] = dist_dw_to_detector_corner_from_detector_center + dist_dw_to_detector_center_from_source_detector_line
 
-  """ Compute image parameters that specify coordinates and bounds relating to the image.
-    For detailed specifications of imgparams, see cone3D.interface_cy_c
+    sinoparams['weightScaler_value'] = -1
+
+    return sinoparams
+
+
+def create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
+                                  delta_pixel_image=1.0, image_slice_offset=0.0):
+    """ Allocate imageparams parameters as required by certain C methods.
+        Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
+        All geometry specifications (i.e. function arguments) are given in laminography coordinates.
+        For detailed specifications of imageparams, see cone3D.interface_cy_c
     
-  Args:
-    sinoparams (dict): Dictionary containing sinogram parameters as required by the Cython code
-    theta (float): Laminographic angle, equal to pi/2 - grazing angle
-    delta_pixel_image (float, optional): [Default=None] Scalar value of image pixel spacing in :math:`ALU`.
-        If None, automatically set to delta_pixel_detector/magnification
-    ror_radius (float, optional): [Default=None] Scalar value of radius of reconstruction in :math:`ALU`.
-        If None, automatically set.
-        Pixels outside the radius ror_radius in the :math:`(x,y)` plane are disregarded in the reconstruction.
-       
-  Returns:
-    Dictionary containing image parameters as required by the Cython code
-  """
+    Args:
+        sinoparams (dict): Dictionary containing sinogram parameters as required by the Cython code
+        num_image_rows (int): Integer number of rows in image region.
+        num_image_cols (int): Integer number of columns in image region.
+        num_image_slices (int): Integer number of slices in image region.
+        theta (float): Laminographic angle, equal to pi/2 - grazing angle
+        delta_pixel_image (float, optional): [Default=None] Scalar value of image pixel spacing in :math:`ALU`.
+            If None, automatically set to delta_pixel_detector/magnification
+        image_slice_offset (float, optional): [Default=0.0] Float that controls vertical offset of the center slice for the reconstruction in units of ALU
 
-  dist_source_detector = -sinoparams['u_s']
+        Returns:
+            Dictionary containing image parameters as required by the Cython code
+    """
 
-  imgparams = dict()
-  imgparams['N_x'] = num_image_rows
-  imgparams['N_y'] = num_image_cols
-  imgparams['N_z'] = num_image_slices
+    dist_source_detector = -sinoparams['u_s']
 
-  imgparams['Delta_xy'] = delta_pixel_image
-  imgparams['Delta_z'] = delta_pixel_image
-  
-  imgparams['x_0'] = -imgparams['N_x']*imgparams['Delta_xy']/2.0
-  imgparams['y_0'] = -imgparams['N_y']*imgparams['Delta_xy']/2.0
-  imgparams['z_0'] = -imgparams['N_z']*imgparams['Delta_z']/2.0 - image_slice_offset - (dist_source_detector / math.tan(theta))
-  
-  # Find coordinates of roi within the voxel image
-  imgparams['j_xstart_roi'] = -1
-  imgparams['j_ystart_roi'] = -1
-  imgparams['j_zstart_roi'] = -1
+    imgparams = dict()
+    imgparams['N_x'] = num_image_rows
+    imgparams['N_y'] = num_image_cols
+    imgparams['N_z'] = num_image_slices
 
-  imgparams['j_xstop_roi'] = -1
-  imgparams['j_ystop_roi'] = -1
-  imgparams['j_zstop_roi'] = -1
+    imgparams['Delta_xy'] = delta_pixel_image
+    imgparams['Delta_z'] = delta_pixel_image
 
-  imgparams['N_x_roi'] = -1
-  imgparams['N_y_roi'] = -1
-  imgparams['N_z_roi'] = -1
+    imgparams['x_0'] = -imgparams['N_x'] * imgparams['Delta_xy'] / 2.0
+    imgparams['y_0'] = -imgparams['N_y'] * imgparams['Delta_xy'] / 2.0
+    imgparams['z_0'] = -imgparams['N_z'] * imgparams['Delta_z'] / 2.0 - image_slice_offset - (dist_source_detector / math.tan(theta))
 
-  return imgparams
+    # Find coordinates of roi within the voxel image
+    imgparams['j_xstart_roi'] = -1
+    imgparams['j_ystart_roi'] = -1
+    imgparams['j_zstart_roi'] = -1
+
+    imgparams['j_xstop_roi'] = -1
+    imgparams['j_ystop_roi'] = -1
+    imgparams['j_zstop_roi'] = -1
+
+    imgparams['N_x_roi'] = -1
+    imgparams['N_y_roi'] = -1
+    imgparams['N_z_roi'] = -1
+
+    return imgparams
 
 
 def recon(sino, angles, dist_source_detector, magnification,
@@ -435,7 +447,7 @@ def recon(sino, angles, dist_source_detector, magnification,
           num_image_rows=None, num_image_cols=None, num_image_slices=None,
           delta_pixel_detector=1.0, delta_pixel_image=None,
           det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0, image_slice_offset=0.0,
-          theta=math.pi/2,
+          theta=math.pi / 2,
           sigma_y=None, snr_db=40.0, sigma_x=None, sigma_p=None, p=1.2, q=2.0, T=1.0, num_neighbors=6,
           sharpness=0.0, positivity=True, max_resolutions=None, stop_threshold=0.02, max_iterations=100,
           num_threads=None, NHICD=False, lib_path=__lib_path,
@@ -448,9 +460,9 @@ def recon(sino, angles, dist_source_detector, magnification,
         dist_source_detector (float): Distance between the X-ray source and the detector in units of ALU
         magnification (float): Magnification of the cone-beam geometry defined as (source to detector distance)/(source to center-of-rotation distance).
         
-        geometry (string, optional): This can be 'cone' or 'lamino'.
+        geometry (string, optional): [Default='cone'] This can be 'cone' or 'lamino'.
             If geometry=='cone', runs a standard cone-beam reconstruction.
-            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset. (Not implemented.)
+            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset.
         
         weights (ndarray, optional): [Default=None] 3D weights array with same shape as sino.
         weight_type (string, optional): [Default='unweighted'] Type of noise model used for data.
@@ -479,7 +491,9 @@ def recon(sino, angles, dist_source_detector, magnification,
         rotation_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from source-detector line to axis of rotation in the object space.
             This is normally set to zero.
         image_slice_offset (float, optional): [Default=0.0] Float that controls vertical offset of the center slice for the reconstruction in units of ALU
-        
+
+        theta (float, optional): [Default=math.pi / 2] Laminographic angle; pi/2 - grazing angle
+
         sigma_y (float, optional): [Default=None] Scalar value of noise standard deviation parameter.
             If None, automatically set with auto_sigma_y.
         snr_db (float, optional): [Default=40.0] Scalar value that controls assumed signal-to-noise ratio of the data in dB.
@@ -527,7 +541,7 @@ def recon(sino, angles, dist_source_detector, magnification,
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
     os.environ['OMP_DYNAMIC'] = 'true'
-    
+
     # Set automatic value of max_resolutions
     if max_resolutions is None:
         max_resolutions = auto_max_resolutions(init_image)
@@ -535,36 +549,43 @@ def recon(sino, angles, dist_source_detector, magnification,
 
     (num_views, num_det_rows, num_det_channels) = sino.shape
 
-    if geometry=='lamino':
-      magnification = 1
+    if geometry == 'lamino':
+        magnification = 1
     if delta_pixel_image is None:
-        delta_pixel_image = delta_pixel_detector/magnification
-        
+        delta_pixel_image = delta_pixel_detector / magnification
+
     if num_image_rows is None:
-        num_image_rows,_,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
+        num_image_rows, _, _ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image,
+                                               magnification)
     if num_image_cols is None:
-        _,num_image_cols,_ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
+        _, num_image_cols, _ = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image,
+                                               magnification)
     if num_image_slices is None:
-        _,_,num_image_slices = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector, delta_pixel_image, magnification)
-        
-    if geometry=='cone':
-      sinoparams = create_sino_params_dict(dist_source_detector, magnification,
-                                       num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
-                                       det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
-                                       rotation_offset=rotation_offset,
-                                       delta_pixel_detector=delta_pixel_detector)
-      
-      imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
-    elif geometry=='lamino':
-      sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
-                                     theta,
-                                     det_channel_offset=det_channel_offset,
-                                     delta_pixel_detector=delta_pixel_detector)
-                                     
-      imgparams = create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
+        _, _, num_image_slices = auto_image_size(num_det_rows, num_det_channels, delta_pixel_detector,
+                                                 delta_pixel_image, magnification)
+
+    if geometry == 'cone':
+        sinoparams = create_sino_params_dict(dist_source_detector, magnification,
+                                             num_views=num_views, num_det_rows=num_det_rows,
+                                             num_det_channels=num_det_channels,
+                                             det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
+                                             rotation_offset=rotation_offset,
+                                             delta_pixel_detector=delta_pixel_detector)
+
+        imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices,
+                                             delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
+    elif geometry == 'lamino':
+        sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
+                                                    theta,
+                                                    det_channel_offset=det_channel_offset,
+                                                    delta_pixel_detector=delta_pixel_detector)
+
+        imgparams = create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
+                                                  delta_pixel_image=delta_pixel_image,
+                                                  image_slice_offset=image_slice_offset)
     else:
-      raise Exception("geometry: undefined geometry {}".format(geometry))
-    
+        raise Exception("geometry: undefined geometry {}".format(geometry))
+
     # make sure that weights do not contain negative entries
     # if weights is provided, and negative entry exists, then do not use the provided weights
     if not ((weights is None) or (np.amin(weights) >= 0.0)):
@@ -576,7 +597,7 @@ def recon(sino, angles, dist_source_detector, magnification,
 
     # Set automatic value of sigma_y
     if sigma_y is None:
-        sigma_y = auto_sigma_y(sino, magnification, weights, snr_db, 
+        sigma_y = auto_sigma_y(sino, magnification, weights, snr_db,
                                delta_pixel_image=delta_pixel_image,
                                delta_pixel_detector=delta_pixel_detector)
 
@@ -667,7 +688,7 @@ def project(image, angles,
             geometry='cone',
             det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
             delta_pixel_detector=1.0, delta_pixel_image=None,
-            theta=math.pi/2,
+            theta=math.pi / 2,
             num_threads=None, verbose=1, lib_path=__lib_path):
     """Compute 3D cone beam forward-projection.
     
@@ -682,7 +703,11 @@ def project(image, angles,
 
         dist_source_detector (float): Distance between the X-ray source and the detector in units of ALU
         magnification (float): Magnification of the cone-beam geometry defined as (source to detector distance)/(source to center-of-rotation distance).
-        
+
+        geometry (string, optional): [Default='cone'] This can be 'cone' or 'lamino'.
+            If geometry=='cone', runs a standard cone-beam reconstruction.
+            If geometry=='lamino', runs a parallel-beam laminography reconstruction and ignores parameters dist_source_detector, magnification, row_offset, rotation_offset.
+
         det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a row.
         det_row_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector to the source-detector line along a column.
         rotation_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from source-detector line to axis of rotation in the object space.
@@ -691,7 +716,9 @@ def project(image, angles,
         delta_pixel_detector (float, optional): [Default=1.0] Scalar value of detector pixel spacing in :math:`ALU`.
         delta_pixel_image (float, optional): [Default=None] Scalar value of image pixel spacing in :math:`ALU`.
             If None, automatically set to delta_pixel_detector/magnification
-        
+
+        theta (float, optional): [Default=math.pi / 2] Laminographic angle; pi/2 - grazing angle
+
         num_threads (int, optional): [Default=None] Number of compute threads requested when executed.
             If None, num_threads is set to the number of cores in the system
         verbose (int, optional): [Default=1] Possible values are {0,1,2}, where 0 is quiet, 1 prints minimal reconstruction progress information, and 2 prints the full information.
@@ -711,27 +738,30 @@ def project(image, angles,
 
     num_views = len(angles)
 
-    if geometry=='cone':
-      sinoparams = create_sino_params_dict(dist_source_detector, magnification,
-                                       num_views=num_views, num_det_rows=num_det_rows, num_det_channels=num_det_channels,
-                                       det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
-                                       rotation_offset=rotation_offset,
-                                       delta_pixel_detector=delta_pixel_detector)
-       
-      (num_image_slices, num_image_rows, num_image_cols) = image.shape
-      
-      imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image)
-    elif geometry=='lamino':
-      sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
-                                     theta,
-                                     det_channel_offset=det_channel_offset,
-                                     delta_pixel_detector=delta_pixel_detector)
-      
-      (num_image_slices, num_image_rows, num_image_cols) = image.shape
+    if geometry == 'cone':
+        sinoparams = create_sino_params_dict(dist_source_detector, magnification,
+                                             num_views=num_views, num_det_rows=num_det_rows,
+                                             num_det_channels=num_det_channels,
+                                             det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
+                                             rotation_offset=rotation_offset,
+                                             delta_pixel_detector=delta_pixel_detector)
 
-      imgparams = create_img_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta, delta_pixel_image=delta_pixel_image)
+        (num_image_slices, num_image_rows, num_image_cols) = image.shape
+
+        imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices,
+                                             delta_pixel_image=delta_pixel_image)
+    elif geometry == 'lamino':
+        sinoparams = create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
+                                                    theta,
+                                                    det_channel_offset=det_channel_offset,
+                                                    delta_pixel_detector=delta_pixel_detector)
+
+        (num_image_slices, num_image_rows, num_image_cols) = image.shape
+
+        imgparams = create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, num_image_slices, theta,
+                                                  delta_pixel_image=delta_pixel_image)
     else:
-      raise Exception("geometry: undefined geometry {}".format(geometry))
+        raise Exception("geometry: undefined geometry {}".format(geometry))
 
     hash_val = _utils.hash_params(angles, sinoparams, imgparams)
     sysmatrix_fname = _utils._gen_sysmatrix_fname(lib_path=lib_path, sysmatrix_name=hash_val[:__namelen_sysmatrix])
@@ -739,7 +769,8 @@ def project(image, angles,
     if os.path.exists(sysmatrix_fname):
         os.utime(sysmatrix_fname)  # update file modified time
     else:
-        sysmatrix_fname_tmp = _utils._gen_sysmatrix_fname_tmp(lib_path=lib_path, sysmatrix_name=hash_val[:__namelen_sysmatrix])
+        sysmatrix_fname_tmp = _utils._gen_sysmatrix_fname_tmp(lib_path=lib_path,
+                                                              sysmatrix_name=hash_val[:__namelen_sysmatrix])
         ci.AmatrixComputeToFile_cy(angles, sinoparams, imgparams, sysmatrix_fname_tmp, verbose=verbose)
         os.rename(sysmatrix_fname_tmp, sysmatrix_fname)
 
@@ -749,6 +780,6 @@ def project(image, angles,
     settings['sinoparams'] = sinoparams
     settings['sysmatrix_fname'] = sysmatrix_fname
     settings['num_threads'] = num_threads
-    
+
     proj = ci.project(image, settings)
     return proj

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -238,7 +238,7 @@ def create_sino_params_dict(dist_source_detector, magnification,
                             det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
                             delta_pixel_detector=1.0):
     """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram.
-        For detailed specifications of sinoparams, see cone3D.interface_cy_c
+        For detailed specifications of sinoparams, see ``cone3D.interface_cy_c``
     
     Args:
         dist_source_detector (float): Distance between the X-ray source and the detector in units of ALU
@@ -290,7 +290,7 @@ def create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, d
                              image_slice_offset=0.0):
     """ Allocate imageparam parameters as required by certain C methods.
         Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
-        For detailed specifications of imageparams, see cone3D.interface_cy_c
+        For detailed specifications of imageparams, see ``cone3D.interface_cy_c``
     
     Args:
         num_image_rows (int): Integer number of rows in image region.
@@ -338,9 +338,9 @@ def create_sino_params_dict_lamino(num_views, num_det_rows, num_det_channels,
                                    det_channel_offset=0.0,
                                    delta_pixel_detector=1.0):
     """ Compute sinogram parameters specify coordinates and bounds relating to the sinogram
-        Function signatures are in laminogram coordinates, output corresponds to sinogram.
+        Function signatures are in laminogram coordinates, output corresponds to internal C-code.
         All geometry specifications (i.e. function arguments) are given in laminography coordinates.
-        For detailed specifications of sinoparams, see cone3D.interface_cy_c
+        For detailed specifications of sinoparams, see ``cone3D.interface_cy_c``
   
     Args:
         num_views (int): Number of views in laminogram data
@@ -395,7 +395,7 @@ def create_image_params_dict_lamino(sinoparams, num_image_rows, num_image_cols, 
     """ Allocate imageparams parameters as required by certain C methods.
         Can be used to describe a region of projection (i.e., when an image is available in ``project`` method), or to specify a region of reconstruction.
         All geometry specifications (i.e. function arguments) are given in laminography coordinates.
-        For detailed specifications of imageparams, see cone3D.interface_cy_c
+        For detailed specifications of imageparams, see ``cone3D.interface_cy_c``
     
     Args:
         sinoparams (dict): Dictionary containing sinogram parameters as required by the Cython code

--- a/mbircone/interface_cy_c.pyx
+++ b/mbircone/interface_cy_c.pyx
@@ -277,7 +277,7 @@ def recon_cy(sino, angles, wght, x_init, proxmap_input,
     cdef cnp.ndarray[float, ndim=3, mode="c"] py_image
 
     # Determine if it the algorithm should reduce resolution further
-    go_to_lower_resolution = (max_resolutions > 0) and (min(imgparams['N_x'], imgparams['N_y'], imgparams['N_z']) > 16)
+    go_to_lower_resolution = (max_resolutions > 0) and (min(imgparams['N_x'], imgparams['N_y'], imgparams['N_z']) > 8)
     
     imgparams_lr = imgparams.copy()
     reconparams_lr = reconparams.copy()

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def gen_shepp_logan(num_rows,num_cols):
     """
     Generate a Shepp Logan phantom
@@ -34,8 +35,8 @@ def gen_shepp_logan(num_rows,num_cols):
 
     for el_paras in sl_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                             gray_level=el_paras['gray_level'])
+                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                              gray_level=el_paras['gray_level'])
 
     return image
 
@@ -71,8 +72,8 @@ def gen_microscopy_sample(num_rows, num_cols):
 
     for el_paras in ms_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                             gray_level=el_paras['gray_level'])
+                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                              gray_level=el_paras['gray_level'])
 
     return image
 
@@ -153,12 +154,10 @@ def gen_shepp_logan_3d_raw(num_rows, num_cols, num_slices, scale=1.0, offset_x=0
 
     for el_paras in sl3d_paras:
         image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0']*scale - shift_x, y0=el_paras['y0']*scale - shift_y,
-                               z0=el_paras['z0']*scale - shift_z,
-                               a=el_paras['a']*scale, b=el_paras['b']*scale, c=el_paras['c']*scale,
-                               gamma=el_paras['gamma'] / 180.0 * np.pi,
-                               gray_level=el_paras['gray_level'])
-
-    
+                                z0=el_paras['z0']*scale - shift_z,
+                                a=el_paras['a']*scale, b=el_paras['b']*scale, c=el_paras['c']*scale,
+                                gamma=el_paras['gamma'] / 180.0 * np.pi,
+                                gray_level=el_paras['gray_level'])
 
     return np.transpose(image, (2, 0, 1))
 
@@ -197,56 +196,59 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     for el_paras in ms3d_paras:
         image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                               z0=el_paras['z0'],
-                               a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
-                               gamma=el_paras['gamma'] / 180.0 * np.pi,
-                               gray_level=el_paras['gray_level'])
+                                z0=el_paras['z0'],
+                                a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
+                                gamma=el_paras['gamma'] / 180.0 * np.pi,
+                                gray_level=el_paras['gray_level'])
 
     return np.transpose(image, (2, 0, 1))
 
+
 def gen_lamino_sample_3d(num_rows, num_cols, num_slices, edge_pixel_thickness=0):
-  """
-  Generate a 3D microscopy sample phantom.
-  Args:
-      num_rows: int, number of rows.
-      num_cols: int, number of cols.
-      num_slices: int, number of slices.
-      edge_pixel_thickness: int, optional, thickness of border around object
-  Return:
-      out_image: 3D array, num_slices*num_rows*num_cols
-  """
+    """
+    Generate a 3D microscopy sample phantom by extracting a window from the gen_microscopy_sample_3d phantom
 
+    Args:
+        num_rows: int, number of rows.
+        num_cols: int, number of cols.
+        num_slices: int, number of slices.
+        edge_pixel_thickness: int, optional, [Default=0] thickness of border around object
+    Return:
+        out_image: 3D array, num_slices*num_rows*num_cols
+    """
 
-  PROPORTION_OF = .54
+    # Cut out a portion of the gen_microscopy_sample_3d phantom
+    PROPORTION_OF = .54
 
-  num_slices_base = int(num_slices / PROPORTION_OF)
-  num_rows_base = int(num_rows / PROPORTION_OF)
-  num_cols_base = int(num_cols / PROPORTION_OF)
+    num_slices_base = int(num_slices / PROPORTION_OF)
+    num_rows_base = int(num_rows / PROPORTION_OF)
+    num_cols_base = int(num_cols / PROPORTION_OF)
 
-  phantom = gen_microscopy_sample_3d(num_rows_base, num_cols_base, num_slices_base)
+    phantom = gen_microscopy_sample_3d(num_rows_base, num_cols_base, num_slices_base)
 
-  slice_start = ( num_slices_base - num_slices ) // 2
-  slice_end = ( num_slices_base + num_slices ) // 2
-  row_start = ( num_rows_base - num_rows ) // 2
-  row_end = ( num_rows_base + num_rows ) // 2
-  col_start = ( num_cols_base - num_cols ) // 2
-  col_end = ( num_cols_base + num_cols ) // 2
+    slice_start = ( num_slices_base - num_slices ) // 2
+    slice_end = ( num_slices_base + num_slices ) // 2
+    row_start = ( num_rows_base - num_rows ) // 2
+    row_end = ( num_rows_base + num_rows ) // 2
+    col_start = ( num_cols_base - num_cols ) // 2
+    col_end = ( num_cols_base + num_cols ) // 2
 
-  phantom = phantom[slice_start:slice_end,row_start:row_end,col_start:col_end]
+    phantom = phantom[slice_start:slice_end,row_start:row_end,col_start:col_end]
 
-  phantom = np.clip(phantom, 0.2, 2.0)
+    phantom = np.clip(phantom, 0.2, 2.0)
 
-  if edge_pixel_thickness <= 0:
-      return phantom
+    if edge_pixel_thickness <= 0:
+        return phantom
 
-  phantom[:edge_pixel_thickness]=2.0
-  phantom[-edge_pixel_thickness:]=2.0
-  phantom[:,:edge_pixel_thickness]=2.0
-  phantom[:,-edge_pixel_thickness:]=2.0
-  phantom[:,:,:edge_pixel_thickness]=2.0
-  phantom[:,:,-edge_pixel_thickness:]=2.0
+    phantom[:edge_pixel_thickness]=2.0
+    phantom[-edge_pixel_thickness:]=2.0
+    phantom[:,:edge_pixel_thickness]=2.0
+    phantom[:,-edge_pixel_thickness:]=2.0
+    phantom[:,:,:edge_pixel_thickness]=2.0
+    phantom[:,:,-edge_pixel_thickness:]=2.0
 
-  return phantom
+    return phantom
+
 
 def nrmse(image, reference_image):
     """

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -204,6 +204,50 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     return np.transpose(image, (2, 0, 1))
 
+def gen_lamino_sample_3d(num_rows, num_cols, num_slices, edge_pixel_thickness=0):
+  """
+  Generate a 3D microscopy sample phantom.
+  Args:
+      num_rows: int, number of rows.
+      num_cols: int, number of cols.
+      num_slices: int, number of slices.
+      edge_pixel_thickness: int, optional, thickness of border around object
+  Return:
+      out_image: 3D array, num_slices*num_rows*num_cols
+  """
+
+
+  PROPORTION_OF = .54
+
+  num_slices_base = int(num_slices / PROPORTION_OF)
+  num_rows_base = int(num_rows / PROPORTION_OF)
+  num_cols_base = int(num_cols / PROPORTION_OF)
+
+  phantom = gen_microscopy_sample_3d(num_rows_base, num_cols_base, num_slices_base)
+
+  slice_start = ( num_slices_base - num_slices ) // 2
+  slice_end = ( num_slices_base + num_slices ) // 2
+  row_start = ( num_rows_base - num_rows ) // 2
+  row_end = ( num_rows_base + num_rows ) // 2
+  col_start = ( num_cols_base - num_cols ) // 2
+  col_end = ( num_cols_base + num_cols ) // 2
+
+  phantom = phantom[slice_start:slice_end,row_start:row_end,col_start:col_end]
+
+  phantom = np.clip(phantom, 0.2, 2.0)
+
+  if edge_pixel_thickness <= 0:
+      return phantom
+
+  phantom[:edge_pixel_thickness]=2.0
+  phantom[-edge_pixel_thickness:]=2.0
+  phantom[:,:edge_pixel_thickness]=2.0
+  phantom[:,-edge_pixel_thickness:]=2.0
+  phantom[:,:,:edge_pixel_thickness]=2.0
+  phantom[:,:,-edge_pixel_thickness:]=2.0
+
+  return phantom
+
 def nrmse(image, reference_image):
     """
     Compute the normalized root mean square error between image and reference_image.


### PR DESCRIPTION
Overview: Add helper methods, implement laminography projection switching on parameter ``geometry`` in ``recon(...)`` and ``project(...)``.

Changes:

- Add methods to ``mbircone/cone3D.py``: ``create_sino_params_dict_lamino(...)`` and ``create_img_params_dict_lamino(...)``.  Call these methods using switch on ``geometry`` parameter in ``recon(...)`` and ``project(...)``.
- Move ``recon(...)`` and ``project(...)`` to top of docstrings (edit ``docs/source/cone3D.rst``)
- Add ``gen_lamino_sample_3d(...)`` to ``mbircone/phantom.py``
- Add ``demo/demo_laminography.py`` demo file

**_Old laminography branch is now deprecated._**