### PR TITLE
Marco/dev — Add 'image_slice_offset' as an arg to 'project'

### DIFF
--- a/demo/test_forward_proj.py
+++ b/demo/test_forward_proj.py
@@ -4,19 +4,20 @@ import mbircone
 from demo_utils import plot_image, plot_gif
 
 """
-This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes
- * generating a 3D Shepp Logan phantom, generating synthetic sinogram data by
- * forward projecting the phantom, performing a 3D qGGMRF reconstruction,
- * and displaying the results.
+The purpose of this script is to test the \'project\' method in cone3D.py. This script generates a small-scale
+ * 9x9 point-spread phantom, and generates a 9x9x64 sinogram. The parameter detector_row_offset
+ * is the stepped from 0.0 to 1.0 by increments of 0.1, and the experiment is repeated for each
+ * increment. Three view angles are printed for each sinogram.
 """
-print('This script is a demonstration of the 3D qGGMRF reconstruction algorithm. Demo functionality includes \
-\n\t * generating a 3D Shepp Logan phantom, generating synthetic sinogram data by \
-\n\t * forward projecting the phantom, performing a 3D qGGMRF reconstruction, \
-\n\t * and displaying the results.')
 
-# ###########################################################################
-# Set the parameters to generate the phantom, synthetic sinogram, and do the recon
-# ###########################################################################
+print('The purpose of this script is to test the \'project\' method in cone3D.py. This script generates a small-scale \
+\n\t * 9x9 point-spread phantom, and generates a 9x9x64 sinogram. The parameter detector_row_offset \
+\n\t * is the stepped from 0.0 to 1.0 by increments of 0.1, and the experiment is repeated for each \
+\n\t * increment. Three view angles are printed for each sinogram.')
+
+# ##################################################################
+# Set the parameters to generate the phantom and synthetic sinogram
+# ##################################################################
 
 # Change the parameters below for your own use case.
 
@@ -24,16 +25,13 @@ print('This script is a demonstration of the 3D qGGMRF reconstruction algorithm.
 num_det_rows = 9
 num_det_channels = 9
 # Geometry parameters
-magnification = 1.0                   # Ratio of (source to detector)/(source to center of rotation)
-dist_factor = 1.0
-dist_source_detector = dist_factor*10*num_det_channels  # distance from source to detector in ALU
+magnification = 1.0  # Ratio of (source to detector)/(source to center of rotation)
+dist_source_detector = 90  # distance from source to detector in ALU
 # number of projection views
 num_views = 64
 # projection angles will be uniformly spaced within the range [0, 2*pi).
 angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
-# qGGMRF recon parameters
-sharpness = 0.0                             # Controls regularization: larger => sharper; smaller => smoother
-T = 0.1                                     # Controls edginess of reconstruction
+
 # display parameters
 vmin = 0.10
 vmax = 0.12
@@ -44,18 +42,18 @@ num_rows_phantom = 9
 num_cols_phantom = 9
 delta_pixel_phantom = 1
 
-
 # local path to save phantom, sinogram, and reconstruction images
-save_path = f'output/debug_forward_proj_mag_{magnification}_dist_{dist_factor}/'
+save_path = f'output/test_forward_proj/'
 os.makedirs(save_path, exist_ok=True)
 
-print('Genrating 3D Shepp Logan phantom ...')
 ######################################################################################
-# Generate a 3D shepp logan phantom
+# Generate 9x9 point-spread phantom
 ######################################################################################
 
-phantom = np.zeros((num_slices_phantom,num_rows_phantom,num_cols_phantom))
-phantom[4,4,4]=1
+print('Genrating 9x9 point-spread phantom ...')
+
+phantom = np.zeros((num_slices_phantom, num_rows_phantom, num_cols_phantom))
+phantom[4, 4, 4] = 1
 
 ######################################################################################
 # Generate synthetic sinogram
@@ -63,37 +61,36 @@ phantom[4,4,4]=1
 
 print('Generating synthetic sinograms ...')
 
-
+# Generate detector offset values
 start = 0.0
 stop = 1.0
 step = 0.1
 for offset in np.arange(start, stop + step, step):
-  sino = mbircone.cone3D.project(phantom, angles,
-                                 num_det_rows, num_det_channels,
-                                 dist_source_detector, magnification, det_row_offset=offset, delta_pixel_image=delta_pixel_phantom)
-  print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
+    sino = mbircone.cone3D.project(phantom, angles,
+                                   num_det_rows, num_det_channels,
+                                   dist_source_detector, magnification, det_row_offset=offset,
+                                   delta_pixel_image=delta_pixel_phantom)
+    print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
 
-  ######################################################################################
-  # Generate phantom, synthetic sinogram, and reconstruction images
-  ######################################################################################
-  # sinogram images
-  for view_idx in [0, num_views//4, num_views//2]:
-      view_angle = int(angles[view_idx]*180/np.pi)
-      plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle}, det_row_offset {offset}',
-                 filename=os.path.join(save_path, f'sino-shepp-logan-3D-offset-{offset}-view-angle-{view_angle}.png'))
-  # Set display indexes for phantom and recon images
-  display_slice_phantom = num_slices_phantom // 2
-  display_x_phantom = num_rows_phantom // 2
-  display_y_phantom = num_cols_phantom // 2
+    # Generate sinogram images
+    for view_idx in [0, num_views // 4, num_views // 2]:
+        view_angle = int(angles[view_idx] * 180 / np.pi)
+        plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle}, det_row_offset {offset}',
+                   filename=os.path.join(save_path, f'sino-shepp-logan-3D-offset-{offset}-view-angle-{view_angle}.png'))
 
-# phantom images
+# Set display indexes for phantom
+display_slice_phantom = num_slices_phantom // 2
+display_x_phantom = num_rows_phantom // 2
+display_y_phantom = num_cols_phantom // 2
+
+# Display phantom images
 plot_image(phantom[display_slice_phantom], title=f'phantom, axial slice {display_slice_phantom}',
            filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
-plot_image(phantom[:,display_x_phantom,:], title=f'phantom, coronal slice {display_x_phantom}',
+plot_image(phantom[:, display_x_phantom, :], title=f'phantom, coronal slice {display_x_phantom}',
            filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
-plot_image(phantom[:,:,display_y_phantom], title=f'phantom, sagittal slice {display_y_phantom}',
+plot_image(phantom[:, :, display_y_phantom], title=f'phantom, sagittal slice {display_y_phantom}',
            filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
-  
-print(f"Images saved to {save_path}.") 
+
+print(f"Images saved to {save_path}.")
 input("Press Enter")
 

--- a/docs/source/clean_install.rst
+++ b/docs/source/clean_install.rst
@@ -1,3 +1,32 @@
 ==================
 Clean installation
 ==================
+
+A number of bash scripts provided in the directory ``dev_scripts`` for cleaning and reinstalling the ``mbircone`` environment.
+
+In order to completely remove ``mbircone``,
+``cd`` into ``dev_scripts`` and run the command::
+
+    $ source clean_mbircone.sh
+
+In order to install ``mbircone`` along with requirements for ``mbircone``, demos, and docs,
+``cd`` into ``dev_scripts`` and run the command::
+
+    $ source install_mbircone.sh
+
+In order to install documentation that can be viewed from ``mbircone/docs/build/html/index.html``,
+``cd`` into ``dev_scripts`` and run the command::
+
+    $ source install_docs.sh
+
+In order to destroy the conda environement named ``mbircone`` and then recreate and activate it,
+``cd`` into ``dev_scripts`` and run the command::
+
+    $ source reinstall_conda_environment.sh
+
+In order to destroy and clean everything, and then recreate the conda environment and reinstall ``mbircone`` and its documentation
+``cd`` into ``dev_scripts`` and run the command::
+
+    $ source clean_install_all.sh
+
+**Be careful with these last two commands** because they will destroy the conda environment named ``svmbir``.

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -1,3 +1,88 @@
 ======
 Theory
 ======
+
+Super-Voxel Model-Based Iterative Reconstruction (SVMBIR) is a fast algorithm for computing MBIR reconstructions from tomographic data.
+MBIR reconstruction works by solving the following optimization problem
+
+.. math::
+
+    {\hat x} = \arg \min_x \left\{ f(x) + h(x) \right\}
+
+where :math:`f(x)` is the forward model term and :math:`h(x)` is the prior model term.
+The super-voxel algorithm is then used to efficiently perform this optimization.
+
+
+**Forward Model:**
+The forward model term has the form,
+
+.. math::
+
+    f(x) = \frac{1}{2 \sigma_y^2} \Vert y - Ax \Vert_\Lambda^2
+
+where :math:`y` is the sinogram data,
+where :math:`x` is the unknown image to be reconstructed,
+:math:`A` is the linear projection operator for the specified imaging geometry,
+:math:`\Lambda` is the diagonal matrix of sinogram weights, :math:`\Vert y \Vert_\Lambda^2 = y^T \Lambda y`, and :math:`\sigma_y` is a parameter controling the assumed standard deviation of the measurement noise.
+
+These quantities correspond to the following python variables:
+
+* :math:`y` corresponds to ``sino``
+* :math:`\sigma_y` corresponds to ``sigma_y``
+* :math:`\Lambda` corresponds to ``weights``
+
+The weights can either be set automatically using the ``weight_type`` input, or they can be explicitly set to an array of precomputed weights.
+For many new users, it is easier to use one of the automatic weight settings shown below.
+
+* weight_type="unweighted" => Lambda = 1 + 0*sino
+* weight_type="transmission" => Lambda = numpy.exp(-sino)
+* weight_type="transmission_root" => Lambda = numpy.exp(-sino/2)
+* weight_type="emmission" => Lambda = (1/(sino + 0.1))
+
+Option "unweighted" provides unweighted reconstruction; Option "transmission" is the correct weighting for transmission CT with constant dosage; Option "transmission_root" is commonly used with transmission CT data to improve image homogeneity; Option "emmission" is appropriate for emission CT data.
+
+**Prior Model:**
+The ``recon`` function allows the prior model to be set either as a qGGMRF or a proximal map prior.
+The qGGRMF prior is the default method recommended for new users.
+Alternatively, the proximal map prior is an advanced feature required for the implementation of the Plug-and-Play algorithm. The Plug-and-Play algorithm allows the modular use of a wide variety of advanced prior models including priors implemented with machine learning methods such as deep neural networks.
+
+The qGGMRF prior model has the form
+
+.. math::
+
+    h(x) = \sum_{ \{s,r\} \in {\cal P}} b_{s,r} \rho ( x_s - x_r) \ ,
+
+where
+
+.. math::
+
+    \rho ( \Delta ) = \frac{|\Delta |^p }{ p \sigma_x^p } \left( \frac{\left| \frac{\Delta }{ T \sigma_x } \right|^{q-p}}{1 + \left| \frac{\Delta }{ T \sigma_x } \right|^{q-p}} \right)
+
+where :math:`{\cal P}` represents a 8-point 2D neighborhood of pixel pairs in the :math:`(x,y)` plane and a 2-point neighborhood along the slice axis;
+:math:`\sigma_x` is the primary regularization parameter;
+:math:`b_{s,r}` controls the neighborhood weighting;
+:math:`p<q=2.0` are shape parameters;
+and :math:`T` is a threshold parameter.
+
+These quantities correspond to the following python variables:
+
+* :math:`\sigma_x` corresponds to ``sigma_x``
+* :math:`p` corresponds to ``p``
+* :math:`q` corresponds to ``q``
+* :math:`T` corresponds to ``T``
+
+
+**Proximal Map Prior:**
+The proximal map prior is provided as a option for advanced users would would like to use plug-and-play methods.
+If ``prox_image`` is supplied, then the proximal map prior model is used, and the qGGMRF parameters are ignored.
+In this case, the reconstruction solves the optimization problem:
+
+.. math::
+
+    {\hat x} = \arg \min_x \left\{ f(x) + \frac{1}{2\sigma_p^2} \Vert x -v \Vert^2 \right\}
+
+where the quantities correspond to the following python variables:
+
+* :math:`v` corresponds to ``prox_image``
+* :math:`\sigma_p` corresponds to ``sigma_p``
+

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -579,7 +579,7 @@ def project(image, angles,
             num_det_rows, num_det_channels,
             dist_source_detector, magnification,
             delta_det_channel=1.0, delta_det_row=1.0, delta_pixel_image=None,
-            det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0,
+            det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0, image_slice_offset=0.0,
             num_threads=None, verbose=1, lib_path=__lib_path):
     """ Compute 3D cone beam forward projection.
     
@@ -638,7 +638,8 @@ def project(image, angles,
      
     (num_image_slices, num_image_rows, num_image_cols) = image.shape
     
-    imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices, delta_pixel_image=delta_pixel_image)
+    imgparams = create_image_params_dict(num_image_rows, num_image_cols, num_image_slices,
+                                         delta_pixel_image=delta_pixel_image, image_slice_offset=image_slice_offset)
 
     hash_val = _utils.hash_params(angles, sinoparams, imgparams)
     sysmatrix_fname = _utils._gen_sysmatrix_fname(lib_path=lib_path, sysmatrix_name=hash_val[:__namelen_sysmatrix])


### PR DESCRIPTION
These changes include the previously discussed changes to cone3D.py, as well as two other minor changes I've made in passing. Namely I added comments to a "test" file I had created in the past, and I added some text to some .rst (read-the-docs) files.

- cone3D.py: Add `image_slice_offset=0.0` to `project` arguments. Add corresponding functionality on lines 641-642.
- test_forward_proj.py: Add explanatory comments and print statements, add comments to code body.
- clean_install.rst, theory.rst: Add explanation of `dev_scripts`; copy-paste MBIR theory explanation from svmbir.

Tested: demo_3D_shepp_logan.py, demo_mace3D_fast.py, install_docs.sh