### PR TITLE
Automatic behavior for 'delta_det_channel', 'delta_det_row'

### DIFF
--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -105,8 +105,12 @@ def auto_delta_det_channel_row(delta_det_channel, delta_det_row):
         delta_det_channel = 1.0
         delta_det_row = 1.0
     elif delta_det_channel is None:
+        warnings.warn("Parameter delta_det_row is provided but delta_det_channel is set to None."
+                      "Setting delta_det_channel = delta_det_row.")
         delta_det_channel = delta_det_row
     elif delta_det_row is None:
+        warnings.warn("Parameter delta_det_channel is provided but delta_det_row is set to None."
+                      "Setting delta_det_row = delta_det_channel.")
         delta_det_row = delta_det_channel
 
     return delta_det_channel, delta_det_row


### PR DESCRIPTION
This pull request implements the following behavior in 'lamino' and 'project':

- Change default values of 'delta_det_channel' and 'delta_det_row' from 1.0 to None.
- Set 'delta_det_channel' and 'delta_det_row' using the method 'auto_delta_det_channel_row', which does the following:
    - If 'delta_det_channel' and 'delta_det_row' are both set to None, set both to 1.0.
    - If one of 'delta_det_channel' and 'delta_det_row' is set to None, set that one to be equal to the other, and raise a warning.
    - If both of 'delta_det_channel' and 'delta_det_row' are set, use those values.

We are implementing this change because it is the desired automatic behavior for 'delta_det_channel' and 'delta_det_row'.