### PR TITLE
data download hotfix

### DIFF
--- a/demo/demo_mace3D.py
+++ b/demo/demo_mace3D.py
@@ -25,17 +25,16 @@ print('This script is a demonstration of the mace3D reconstruction algorithm. De
 
 # Change the parameters below for your own use case.
 
-# The url to the data repo.
-data_repo_url = 'https://github.com/cabouman/mbir_data/raw/master/'
+##### urls to phantom and denoiser parameter file
+# url to download the 3D image volume phantom file
+phantom_url = "https://engineering.purdue.edu/~bouman/data_repository/data/bottle_cap_3D_phantom.npy.tgz"  # name of the phantom file. Please make sure this matches with the name of the downloaded file.
+phantom_name = 'bottle_cap_3D_phantom.npy'
 
-# Download url to the index file.
-# This file will be used to retrieve urls to files that we are going to download
-yaml_url = os.path.join(data_repo_url, 'index.yaml')
+# url to download the denoiser parameter file
+denoiser_url = "https://engineering.purdue.edu/~bouman/data_repository/data/model_dncnn_ct.tgz"
+# name of the directory containing all denoiser param files. Make sure this matches with the name of the downloaded file.
+denoiser_model_name = 'model_dncnn_ct'
 
-# Choice of phantom file. 
-# These should be valid choices specified in the index file. 
-# The url to phantom data will be parsed from data_repo_url and the choices of phantom specified below.
-phantom_name = 'bottle_cap_3D'
 
 # destination path to download and extract the phantom and NN weight files.
 target_dir = './demo_data/'   
@@ -60,21 +59,18 @@ max_admm_itr = 10            # max ADMM iterations for MACE reconstruction
 # Download and extract data 
 # ###########################################################################
 
-# Download the url index file and return path to local file. 
-index_path = demo_utils.download_and_extract(yaml_url, target_dir) 
-# Load the url index file as a directionary
-url_index = demo_utils.load_yaml(index_path)
-# get urls to phantom and denoiser parameter file
-phantom_url = os.path.join(data_repo_url, url_index['phantom'][phantom_name])  # url to download the 3D image volume phantom file
-denoiser_url = os.path.join(data_repo_url, url_index['denoiser']['dncnn_ct'])  # url to download the denoiser parameter file 
+#### download phantom file
+# retrieve parent directory where phantom npy file is extracted to
+phantom_dir = demo_utils.download_and_extract(phantom_url, target_dir)
+phantom_full_path = os.path.join(phantom_dir, phantom_name)
 
-# download phantom file
-phantom_path = demo_utils.download_and_extract(phantom_url, target_dir)
-# download and extract NN weights and structure files used for MACE denoiser
-denoiser_path = demo_utils.download_and_extract(denoiser_url, target_dir)
+#### download and extract NN weights and structure files
+# retrieve parent directory where denoiser files are extracted to
+denoiser_model_dir = demo_utils.download_and_extract(denoiser_url, target_dir)
+denoiser_model_full_path = os.path.join(denoiser_model_dir, denoiser_model_name)
 
 # load original phantom
-phantom = np.load(phantom_path) / 4.
+phantom = np.load(phantom_full_path) / 4.
 print("shape of phantom = ", phantom.shape)
 
 
@@ -104,7 +100,7 @@ recon_qGGMRF = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnifi
 # This demo includes a custom DnCNN denoiser trained on CT images, which can be used for other applications.
 print("Loading denoiser function and model ...")
 # Load denoiser model structure and pre-trained model weights
-denoiser_model = denoiser_utils.DenoiserCT(checkpoint_dir=os.path.join(denoiser_path, 'model_dncnn_ct'))
+denoiser_model = denoiser_utils.DenoiserCT(checkpoint_dir=denoiser_model_full_path)
 # Define the denoiser using this model.  This version requires some interface code to match with MACE.
 def denoiser(img_noisy):
     img_noisy = np.expand_dims(img_noisy, axis=1)

--- a/demo/demo_mace4D.py
+++ b/demo/demo_mace4D.py
@@ -39,21 +39,15 @@ if __name__=='__main__':
     # Denoiser function to be used in MACE. For the built-in demo, this should be one of dncnn_keras or dncnn_ct
     # Other denoisers built in keras can be used with minimal modification by putting the architecture and weights
     # in model.json and model.hdf5 in the denoiser_path set below
-    denoiser_type = 'dncnn_ct'
-
-    # The url to the data repo.
-    data_repo_url = 'https://github.com/cabouman/mbir_data/raw/master/'
-
-    # Download url to the index file.
-    # This file will be used to retrieve urls to files that we are going to download
-    yaml_url = os.path.join(data_repo_url, 'index.yaml')
-
-    # Choice of phantom and denoiser files. 
-    # These should be valid choices specified in the index file. 
-    # The urls to phantom data and NN weights will be parsed from data_repo_url and the choices of phantom and denoiser specified below.
-    phantom_name = 'bottle_cap_3D'
-    denoiser_name = denoiser_type
-
+    
+    ##### urls to phantom and denoiser parameter file
+    # url to download the 3D image volume phantom file
+    phantom_url = "https://engineering.purdue.edu/~bouman/data_repository/data/bottle_cap_3D_phantom.npy.tgz"
+    # name of the phantom file. Please make sure this matches with the name of the downloaded file.
+    phantom_name = 'bottle_cap_3D_phantom.npy'
+    # url to download the denoiser parameter file
+    denoiser_url = "https://engineering.purdue.edu/~bouman/data_repository/data/model_dncnn_ct.tgz"
+    
     # destination path to download and extract the phantom and NN weight files.
     target_dir = './demo_data/'   
     # path to store output recon images
@@ -82,18 +76,13 @@ if __name__=='__main__':
     # ###########################################################################
     # Download and extract data 
     # ###########################################################################
+    #### download phantom file
+    # retrieve parent directory where phantom npy file is extracted to
+    phantom_dir = demo_utils.download_and_extract(phantom_url, target_dir)
+    phantom_full_path = os.path.join(phantom_dir, phantom_name)
 
-    # Download the url index file and return path to local file. 
-    index_path = demo_utils.download_and_extract(yaml_url, target_dir) 
-    # Load the url index file as a directionary
-    url_index = demo_utils.load_yaml(index_path)
-    # get urls to phantom and denoiser parameter file
-    phantom_url = os.path.join(data_repo_url, url_index['phantom'][phantom_name])  # url to download the 3D image volume phantom file
-    denoiser_url = os.path.join(data_repo_url, url_index['denoiser'][denoiser_name])  # url to download the denoiser parameter file 
-
-    # download phantom file
-    phantom_path = demo_utils.download_and_extract(phantom_url, target_dir)
-    # download and extract NN weights and structure files
+    #### download and extract NN weights and structure files
+    # retrieve parent directory where denoiser files are extracted to
     denoiser_path = demo_utils.download_and_extract(denoiser_url, target_dir)
 
     
@@ -152,7 +141,7 @@ if __name__=='__main__':
     print("Loading 3D phantom volume ...")
 
     # load original phantom
-    phantom_3D = np.load(phantom_path)
+    phantom_3D = np.load(phantom_full_path)
     print("shape of 3D phantom = ", phantom_3D.shape)
 
     # ###########################################################################


### PR DESCRIPTION
This is a hot fix to the download urls in the MACE demo scripts.
Dataset & DnCNN model urls now point to the new download url instead of GitHub repo.
There's also a minor update on the data download process in the demo (Mostly changes in comments and variable names).