### PR TITLE
Module/laminography

### DIFF
--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -34,6 +34,11 @@ num_slices_phantom = 16
 num_rows_phantom = 64
 num_cols_phantom = 64
 
+# Reconstruction parameters
+num_slices_image = 16
+num_rows_image = 146
+num_cols_image = 146
+
 # Size of constant padding around phantom as a multiple of num_rows_phantom or num_cols_phantom
 pad_factor = 2
 
@@ -86,8 +91,8 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 print('Performing 3D qGGMRF reconstruction ...')
 
 recon = mbircone.laminography.recon_lamino(sino, angles, theta_radians,
-                                           num_image_rows=192,
-                                           num_image_cols=192,
+                                           num_image_rows=146,
+                                           num_image_cols=146,
                                            num_image_slices=16,
                                            sharpness=sharpness, snr_db=snr_db)
 
@@ -140,7 +145,7 @@ phantom_area_of_interest = phantom[:, phantom_row_start:phantom_row_end, phantom
 # Compute and display reconstruction error in phantom region
 display_error = np.abs(phantom_area_of_interest - recon_area_of_interest)
 
-print(f'qGGMRF rms reconstruction error within 16x128x128 laminography phantom window: '
+print(f'qGGMRF normalized rms reconstruction error within 16x128x128 laminography phantom window: '
       f'{np.sqrt(np.mean(display_error**2))/np.mean(phantom_area_of_interest):.3g}')
 
 # Set display indexes for phantom and recon images

--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -1,0 +1,170 @@
+import os
+import numpy as np
+import mbircone
+from demo_utils import plot_image, plot_gif
+
+
+"""
+This script is a demonstration of the laminography reconstruction algorithm. Demo functionality includes
+ * Generating a 3D laminography sample phantom;
+ * Generating synthetic laminography data by forward projecting the phantom.
+ * Performing a 3D qGGMRF reconstruction.
+ * Displaying the results.
+"""
+print('This script is a demonstration of the laminography reconstruction algorithm. Demo functionality includes \
+\n\t * Generating a 3D laminography sample phantom; \
+\n\t * Generating synthetic laminography data by forward projecting the phantom. \
+\n\t * Performing a 3D qGGMRF reconstruction. \
+\n\t * Displaying the results.')
+
+# Laminographic angle
+theta_degrees = 60
+# Convert to radians
+theta_radians = theta_degrees * (np.pi/180)
+
+# detector size
+num_det_channels = 128
+num_det_rows = 128
+
+# number of projection views
+num_views = 128
+
+# Phantom parameters
+num_slices_phantom = 16
+num_rows_phantom = 90
+num_cols_phantom = 90
+
+# Reconstruction size
+num_image_slices = 18
+num_image_rows = 320
+num_image_cols = 320
+
+# qGGMRF recon parameters
+sharpness = 0.0                    # Controls regularization level of reconstruction by controlling prior term weighting
+snr_db = 30
+
+# display parameters
+vmin = 0.0
+vmax = 0.1
+
+
+# Compute projection angles uniformly spaced within the range [0, 2*pi).
+angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
+
+# local path to save phantom, sinogram, and reconstruction images
+save_path = f'output/laminography_tests/'
+os.makedirs(save_path, exist_ok=True)
+
+######################################################################################
+# Generate laminography phantom, pad with 'constant' values
+######################################################################################
+
+print('Generating a laminography phantom ...')
+phantom = mbircone.phantom.gen_lamino_sample_3d(num_rows_phantom, num_cols_phantom, num_slices_phantom, pad_factor=3)
+
+# Scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
+phantom = phantom/10.0
+print('Phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
+
+
+######################################################################################
+# Generate synthetic sinogram
+######################################################################################
+
+print('Generating synthetic sinogram ...')
+sino = mbircone.laminography.project_lamino(phantom, angles, theta_radians,
+                                            num_det_rows, num_det_channels)
+print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = ', sino.shape)
+
+
+######################################################################################
+# Perform 3D qGGMRF reconstruction
+######################################################################################
+
+print('Performing 3D qGGMRF reconstruction ...')
+
+recon = mbircone.laminography.recon_lamino(sino, angles, theta_radians,
+                                           num_image_rows=num_image_rows,
+                                           num_image_cols=num_image_cols, num_image_slices=num_image_slices,
+                                           sharpness=sharpness, snr_db=snr_db)
+
+print('recon shape = ', np.shape(recon))
+
+
+#####################################################################################
+# Generate phantom, synthetic sinogram, and reconstruction images
+#####################################################################################
+# sinogram images
+for view_idx in [0, num_views//4, num_views//2]:
+        view_angle = int(angles[view_idx]*180/np.pi)
+        plot_image(sino[view_idx, :, :], title=f'sinogram view angle {view_angle} ',
+                   filename=os.path.join(save_path, f'sino-shepp-logan-3D-view_angle{view_angle}.png'),
+                   vmin=0.0, vmax=2.0)
+
+plot_image(sino[0,:,:]-sino[num_views//4,:,:],
+           title=f'sinogram view angle {0} minus view angle'
+                 f' {int(angles[num_views//4]*180/np.pi)}',
+           filename=os.path.join(save_path, f'sinogram-difference.png'),
+           vmin=0.0, vmax=2.0)
+
+plot_image(np.abs(sino[0,:,:]-sino[num_views//3,:,:]),
+           title=f'sinogram view angle {0} minus view angle'
+                 f' {int(angles[num_views//3]*180/np.pi)}',
+           filename=os.path.join(save_path, f'sinogram-difference.png'),
+           vmin=0.0, vmax=2.0)
+
+display_phantom = phantom
+display_recon = recon
+
+# recon_area_of_interest = recon[1:18, 96:225, 96:225]
+recon_area_of_interest = recon[1:17, 96:224, 96:224]
+display_error = np.abs(phantom[48:64, 251:379, 251:379] - recon_area_of_interest)
+
+print(f'qGGMRF rms reconstruction error within 16x128x128 laminography phantom window: '
+      f'{np.sqrt(np.mean(display_error**2))/np.mean(phantom[48:64, 251:379, 251:379]):.3g}')
+
+# Set display indexes for phantom and recon images
+display_slice_image = display_phantom.shape[0] // 2
+display_x_image = display_phantom.shape[1] // 2
+display_y_image = display_phantom.shape[2] // 2
+
+display_slice_recon = display_recon.shape[0] // 2
+display_x_recon = display_recon.shape[1] // 2
+display_y_recon = display_recon.shape[2] // 2
+
+display_slice_error = display_error.shape[0] // 2
+display_x_error = display_error.shape[1] // 2
+display_y_error = display_error.shape[2] // 2
+
+# phantom images
+plot_image(display_phantom[display_slice_image], title=f'phantom, axial slice {display_slice_image}',
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_phantom[:,display_x_image,:], title=f'phantom, coronal slice {display_x_image}',
+           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_phantom[:,:,display_y_image], title=f'phantom, sagittal slice {display_y_image}',
+           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+# recon images
+plot_image(display_recon[display_slice_recon], title=f'qGGMRF recon, axial slice {display_slice_recon}, '
+                                                     f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'recon_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_recon[:, display_x_recon,:], title=f'qGGMRF recon, coronal slice {display_x_recon}, '
+                                                      f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'recon_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_recon[:, :, display_y_recon], title=f'qGGMRF recon, sagittal slice {display_y_recon}, '
+                                                       f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'recon_sagittal.png'), vmin=vmin, vmax=vmax)
+
+# error images
+plot_image(display_error[display_slice_error], title=f'error, axial slice {display_slice_error}, '
+                                                     f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'error_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(display_error[:, display_x_error,:], title=f'error, coronal slice {display_x_error}, '
+                                                      f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'error_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(display_error[:, :, display_y_error], title=f'error, sagittal slice {display_y_error}, '
+                                                       f'Θ='+str(theta_degrees)+' degrees',
+           filename=os.path.join(save_path, 'error_sagittal.png'), vmin=vmin, vmax=vmax)
+
+
+print(f"Images saved to {save_path}.")
+input("Press Enter")

--- a/demo/demo_laminography.py
+++ b/demo/demo_laminography.py
@@ -27,23 +27,20 @@ num_det_channels = 64
 num_det_rows = 64
 
 # number of projection views
-num_views = 128
+num_views = 64
 
 # Phantom parameters
-num_slices_phantom = 16
-num_rows_phantom = 64
-num_cols_phantom = 64
+num_phantom_slices = 16
+num_phantom_rows = 64
+num_phantom_cols = 64
 
 # Reconstruction parameters
-num_slices_image = 16
-num_rows_image = 146
-num_cols_image = 146
+num_image_slices = 16
+num_image_rows = 146
+num_image_cols = 146
 
-# Size of constant padding around phantom as a multiple of num_rows_phantom or num_cols_phantom
+# Size of constant padding around phantom as a multiple of num_phantom_rows or num_phantom_cols
 pad_factor = 2
-
-# Reconstruction size
-num_image_slices = 18
 
 # qGGMRF recon parameters
 sharpness = 0.0                    # Controls regularization level of reconstruction by controlling prior term weighting
@@ -66,12 +63,12 @@ os.makedirs(save_path, exist_ok=True)
 ######################################################################################
 
 print('Generating a laminography phantom ...')
-phantom = mbircone.phantom.gen_lamino_sample_3d(num_rows_phantom, num_cols_phantom,
-                                                num_slices_phantom, pad_factor=pad_factor)
+phantom = mbircone.phantom.gen_lamino_sample_3d(num_phantom_rows, num_phantom_cols,
+                                                num_phantom_slices, pad_factor=pad_factor)
 
 # Scale the phantom by a factor of 10.0 to make the projections physical realistic -log attenuation values
 phantom = phantom/10.0
-print('Phantom shape is:', num_slices_phantom, num_rows_phantom, num_cols_phantom)
+print('Phantom shape is:', num_phantom_slices, num_phantom_rows, num_phantom_cols)
 
 
 ######################################################################################
@@ -91,9 +88,9 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 print('Performing 3D qGGMRF reconstruction ...')
 
 recon = mbircone.laminography.recon_lamino(sino, angles, theta_radians,
-                                           num_image_rows=146,
-                                           num_image_cols=146,
-                                           num_image_slices=16,
+                                           num_image_rows=num_image_rows,
+                                           num_image_cols=num_image_cols,
+                                           num_image_slices=num_image_slices,
                                            sharpness=sharpness, snr_db=snr_db)
 
 print('recon shape = ', np.shape(recon))
@@ -124,22 +121,22 @@ plot_image(np.abs(sino[0,:,:]-sino[num_views//3,:,:]),
 display_phantom = phantom
 display_recon = recon
 
-(num_slices_image, num_rows_image, num_cols_image) = np.shape(recon)
+(num_image_slices, num_image_rows, num_image_cols) = np.shape(recon)
 
 # Determine where the relevant phantom region begins and ends
-recon_row_start = int((num_rows_image-num_rows_phantom)/2)
-recon_row_end = recon_row_start + num_rows_phantom
-recon_col_start = int((num_cols_image-num_cols_phantom)/2)
-recon_col_end = recon_col_start + num_cols_phantom
-recon_slice_start = int((num_slices_image-num_slices_phantom)/2)
-recon_slice_end = recon_slice_start + num_slices_phantom
+recon_row_start = int((num_image_rows-num_phantom_rows)/2)
+recon_row_end = recon_row_start + num_phantom_rows
+recon_col_start = int((num_image_cols-num_phantom_cols)/2)
+recon_col_end = recon_col_start + num_phantom_cols
+recon_slice_start = int((num_image_slices-num_phantom_slices)/2)
+recon_slice_end = recon_slice_start + num_phantom_slices
 recon_area_of_interest = recon[recon_slice_start:recon_slice_end, recon_row_start:recon_row_end,
                          recon_col_start:recon_col_end]
 
-phantom_row_start = int(num_rows_phantom * pad_factor)
-phantom_row_end = phantom_row_start + num_rows_phantom
-phantom_col_start = int(num_cols_phantom * pad_factor)
-phantom_col_end = phantom_col_start + num_cols_phantom
+phantom_row_start = int(num_phantom_rows * pad_factor)
+phantom_row_end = phantom_row_start + num_phantom_rows
+phantom_col_start = int(num_phantom_cols * pad_factor)
+phantom_col_end = phantom_col_start + num_phantom_cols
 phantom_area_of_interest = phantom[:, phantom_row_start:phantom_row_end, phantom_col_start:phantom_col_end]
 
 # Compute and display reconstruction error in phantom region

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,12 +7,14 @@ API reference
 * preprocess_ includes functions for sinogram preprocessing and parameters parsing for both 3D and 4D conebeam datasets.
 * mace_ includes functions for multi-slice MACE reconstruction of both 3D and 4D conebeam tomography.
 * multinode_ includes functions for easily deployment on multi-nodes with Dask, a flexible library for parallel computing in Python.
+* laminography_ includes functions for 3D parallel beam laminographic projection and reconstruction
 
 .. _cone3D: cone3D.html
 .. _phantom: phantom.html
 .. _preprocess: preprocess.html
 .. _mace: mace.html
 .. _multinode: multinode.html
+.. _laminography: laminography.html
 .. toctree::
    :titlesonly:
    :hidden:
@@ -22,3 +24,4 @@ API reference
    preprocess
    mace
    multinode
+   laminography

--- a/docs/source/laminography.rst
+++ b/docs/source/laminography.rst
@@ -1,0 +1,13 @@
+mbircone.laminography
+------------------
+.. automodule:: mbircone.laminography
+   :members: recon_lamino, project_lamino
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: **Functions:**
+
+   .. autosummary::
+
+      recon_lamino
+      project_lamino

--- a/docs/source/laminography.rst
+++ b/docs/source/laminography.rst
@@ -1,5 +1,5 @@
 mbircone.laminography
-------------------
+---------------------
 .. automodule:: mbircone.laminography
    :members: recon_lamino, project_lamino
    :undoc-members:

--- a/mbircone/__init__.py
+++ b/mbircone/__init__.py
@@ -4,4 +4,5 @@ from .cone3D import *
 from .mace import mace3D, mace4D
 from .phantom import *
 from .multinode import *
+from .laminography import *
 #__all__ = ['auto_sigma_x','auto_sigma_p','auto_sigma_y', 'calc_weights', 'compute_sino_params', 'compute_img_params', 'compute_img_size', 'project', 'recon', 'pad_roi2ror', 'extract_roi_from_ror']

--- a/mbircone/laminography.py
+++ b/mbircone/laminography.py
@@ -54,7 +54,7 @@ def auto_lamino_params(theta, num_det_rows, num_det_channels, delta_det_channel,
 
 
 def auto_image_size_lamino(theta, num_det_rows, num_det_channels, delta_det_row, delta_det_channel, delta_pixel_image):
-    """ Compute the automatic image array size for use in MBIR reconstruction.
+    """ Compute the automatic image array size for use in MBIR reconstruction. Currently unused.
 
     Args:
         theta (float): Angle that source-detector line makes with the object vertical axis.

--- a/mbircone/laminography.py
+++ b/mbircone/laminography.py
@@ -55,7 +55,7 @@ def auto_lamino_params(theta, num_det_rows, num_det_channels, delta_det_channel,
 def recon_lamino(sino, angles, theta,
                  weights=None, weight_type='unweighted', init_image=0.0, prox_image=None,
                  num_image_rows=None, num_image_cols=None, num_image_slices=None,
-                 delta_det_channel=None, delta_det_row=None, delta_pixel_image=None,
+                 delta_det_channel=1.0, delta_det_row=1.0, delta_pixel_image=None,
                  det_channel_offset=0.0, image_slice_offset=0.0,
                  sigma_y=None, snr_db=40.0, sigma_x=None, sigma_p=None, p=1.2, q=2.0, T=1.0, num_neighbors=6,
                  sharpness=0.0, positivity=True, max_resolutions=None, stop_threshold=0.02, max_iterations=100,
@@ -87,10 +87,8 @@ def recon_lamino(sino, angles, theta,
         num_image_slices (int, optional): [Default=None] Number of slices in reconstructed image.
             If None, automatically set by ``cone3D.auto_image_size``.
 
-        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`. If None, set to
-            value of delta_det_row. If delta_det_row is None, set both to 1.0.
-        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`. If None, set to
-            value of delta_det_channel. If delta_det_channel is None, set both to 1.0.
+        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`.
+        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`.
         delta_pixel_image (float, optional): [Default=None] Image pixel spacing in :math:`ALU`.
             If None, automatically set to ``delta_det_channel/magnification``.
 
@@ -143,8 +141,6 @@ def recon_lamino(sino, angles, theta,
 
     (_, num_det_rows, num_det_channels) = sino.shape
 
-    (delta_det_channel, delta_det_row) = cone3D.auto_delta_det_channel_row(delta_det_channel, delta_det_row)
-
     lamino_dist_source_detector, lamino_magnification, lamino_delta_det_row, lamino_det_row_offset, \
         lamino_rotation_offset, lamino_image_slice_offset = auto_lamino_params(theta, num_det_rows, num_det_channels,
                                                                                delta_det_channel, delta_det_row,
@@ -169,7 +165,7 @@ def recon_lamino(sino, angles, theta,
 
 def project_lamino(image, angles, theta,
                    num_det_rows, num_det_channels,
-                   delta_det_channel=None, delta_det_row=None, delta_pixel_image=None,
+                   delta_det_channel=1.0, delta_det_row=1.0, delta_pixel_image=None,
                    det_channel_offset=0.0, image_slice_offset=0.0,
                    num_threads=None, verbose=1, lib_path=__lib_path):
     """ Compute 3D cone beam forward projection for the laminography case.
@@ -182,10 +178,8 @@ def project_lamino(image, angles, theta,
         num_det_rows (int): Number of rows in laminography sinogram data.
         num_det_channels (int): Number of channels in laminography sinogram data.
 
-        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`. If None, set to
-            value of delta_det_row. If delta_det_row is None, set both to 1.0.
-        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`. If None, set to
-            value of delta_det_channel. If delta_det_channel is None, set both to 1.0.
+        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`.
+        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`.
         delta_pixel_image (float, optional): [Default=None] Image pixel spacing in :math:`ALU`.
             If None, automatically set to ``delta_det_channel/magnification``.
 
@@ -204,8 +198,6 @@ def project_lamino(image, angles, theta,
     Returns:
         (float, ndarray): 3D laminography sinogram with shape (num_views, num_det_rows, num_det_channels).
     """
-
-    (delta_det_channel, delta_det_row) = cone3D.auto_delta_det_channel_row(delta_det_channel, delta_det_row)
 
     lamino_dist_source_detector, lamino_magnification, lamino_delta_det_row, lamino_det_row_offset, \
         lamino_rotation_offset, lamino_image_slice_offset = auto_lamino_params(theta, num_det_rows, num_det_channels,

--- a/mbircone/laminography.py
+++ b/mbircone/laminography.py
@@ -127,11 +127,11 @@ def recon_lamino(sino, angles, theta,
             (num_img_slices, num_img_rows, num_img_cols).
 
         num_image_rows (int, optional): [Default=None] Number of rows in reconstructed image.
-            If None, automatically set by ``laminography.auto_image_size_lamino``.
+            If None, automatically set by ``cone3D.auto_image_size``.
         num_image_cols (int, optional): [Default=None] Number of columns in reconstructed image.
-            If None, automatically set by ``laminography.auto_image_size_lamino``.
+            If None, automatically set by ``cone3D.auto_image_size``.
         num_image_slices (int, optional): [Default=None] Number of slices in reconstructed image.
-            If None, automatically set by ``laminography.auto_image_size_lamino``.
+            If None, automatically set by ``cone3D.auto_image_size``.
 
         delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`.
         delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`.

--- a/mbircone/laminography.py
+++ b/mbircone/laminography.py
@@ -1,0 +1,225 @@
+import numpy as np
+import os
+import mbircone.cone3D as cone3D
+
+__lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
+
+
+def auto_lamino_params(theta, num_det_rows, num_det_channels, delta_det_channel, delta_det_row, image_slice_offset):
+    """ Compute values for parameters used internally for a synthetic cone beam approximation of laminography.
+
+    Args:
+        theta (float): Angle that source-detector line makes with the object vertical axis.
+        num_det_rows (int): Number of rows in laminography sinogram data.
+        num_det_channels (int): Number of channels in laminography sinogram data.
+
+        delta_det_channel (float): Detector channel spacing in :math:`ALU`.
+        delta_det_row (float): Detector row spacing in :math:`ALU`.
+
+        image_slice_offset (float): Vertical offset of the image in units of :math:`ALU`.
+
+    Returns:
+        (float, tuple): Values for ``lamino_dist_source_detector``, ``lamino_magnification``,
+        ``lamino_delta_det_row`` ``lamino_det_row_offset``, ``lamino_rotation_offset``,
+        ``lamino_image_slice_offset`` for the inputted image measurements.
+    """
+
+    # Determine artificial source-detector distance to approximate parallel beams
+    # Beams spread by less than epsilon * max(delta_det_channel,delta_det_row) as they pass through the phantom
+    epsilon = 0.0015
+    lamino_dist_source_detector = (1 / epsilon) * max(delta_det_channel, delta_det_row) * \
+                                  (max(num_det_rows, num_det_channels) ** 2)
+
+    # Setting _magnification=1.0 with a large _dist_source_detector approximates parallel beams
+    lamino_magnification = 1.0
+
+    # Compute synthetic detector pixel size corresponding to affine projection of
+    # real parallel-beam laminography detector onto synthetic cone-beam detector
+    lamino_delta_det_row = delta_det_row / np.sin(theta)
+
+    # Move synthetic cone-beam detector downward so that the incident cone-beam angle corresponds
+    # to the real laminographic angle.
+    lamino_det_row_offset = lamino_dist_source_detector / np.tan(theta)
+
+    # Since there is no source-detector line in parallel-beam projection, define the
+    # synthetic source-detector line to intersect the axis of rotation; so _rotation_offset=0.0
+    lamino_rotation_offset = 0.0
+
+    # Move the image region to correspond with the movement of the synthetic cone-beam detector
+    lamino_image_slice_offset = image_slice_offset + lamino_det_row_offset
+
+    return lamino_dist_source_detector, lamino_magnification, lamino_delta_det_row, lamino_det_row_offset, \
+        lamino_rotation_offset, lamino_image_slice_offset
+
+
+def recon_lamino(sino, angles, theta,
+                 weights=None, weight_type='unweighted', init_image=0.0, prox_image=None,
+                 num_image_rows=None, num_image_cols=None, num_image_slices=None,
+                 delta_det_channel=None, delta_det_row=None, delta_pixel_image=None,
+                 det_channel_offset=0.0, image_slice_offset=0.0,
+                 sigma_y=None, snr_db=40.0, sigma_x=None, sigma_p=None, p=1.2, q=2.0, T=1.0, num_neighbors=6,
+                 sharpness=0.0, positivity=True, max_resolutions=None, stop_threshold=0.02, max_iterations=100,
+                 NHICD=False, num_threads=None, verbose=1, lib_path=__lib_path):
+    """ Compute 3D cone beam MBIR reconstruction for the laminography case.
+
+    Args:
+        sino (float, ndarray): 3D laminography sinogram data with shape (num_views, num_det_rows, num_det_channels).
+        angles (float, ndarray): 1D array of view angles in radians.
+        theta (float): Angle that source-detector line makes with the object vertical axis.
+
+        weights (float, ndarray, optional): [Default=None] 3D weights array with same shape as ``sino``.
+            If ``weights`` is not supplied, then ``cone3D.calc_weights`` is used to set weights using ``weight_type``.
+        weight_type (string, optional): [Default='unweighted'] Type of noise model used for data.
+
+                - ``'unweighted'`` corresponds to unweighted reconstruction;
+                - ``'transmission'`` is the correct weighting for transmission CT with constant dosage;
+                - ``'transmission_root'`` is commonly used with transmission CT data to improve image homogeneity;
+                - ``'emission'`` is appropriate for emission CT data.
+        init_image (float, ndarray, optional): [Default=0.0] Initial value of reconstruction image, specified by either
+            a scalar value or a 3D numpy array with shape (num_img_slices, num_img_rows, num_img_cols).
+        prox_image (float, ndarray, optional): [Default=None] 3D proximal map input image with shape
+            (num_img_slices, num_img_rows, num_img_cols).
+
+        num_image_rows (int, optional): [Default=None] Number of rows in reconstructed image.
+            If None, automatically set by ``cone3D.auto_image_size``.
+        num_image_cols (int, optional): [Default=None] Number of columns in reconstructed image.
+            If None, automatically set by ``cone3D.auto_image_size``.
+        num_image_slices (int, optional): [Default=None] Number of slices in reconstructed image.
+            If None, automatically set by ``cone3D.auto_image_size``.
+
+        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`. If None, set to
+            value of delta_det_row. If delta_det_row is None, set both to 1.0.
+        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`. If None, set to
+            value of delta_det_channel. If delta_det_channel is None, set both to 1.0.
+        delta_pixel_image (float, optional): [Default=None] Image pixel spacing in :math:`ALU`.
+            If None, automatically set to ``delta_det_channel/magnification``.
+
+        det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector
+            to the detector z-axis along a row. (Note: There is no ``det_row_offset`` parameter; due to the
+            parallel beam geometry such a parameter would not have an effect.)
+        image_slice_offset (float, optional): [Default=0.0] Vertical offset of the image in units of :math:`ALU`.
+
+        sigma_y (float, optional): [Default=None] Forward model regularization parameter.
+            If None, automatically set with ``cone3D.auto_sigma_y``.
+        snr_db (float, optional): [Default=40.0] Assumed signal-to-noise ratio of the data in :math:`dB`.
+            Ignored if ``sigma_y`` is not None.
+        sigma_x (float, optional): [Default=None] qGGMRF prior model regularization parameter.
+            If None, automatically set with ``cone3D.auto_sigma_x`` as a function of ``sharpness``.
+            If ``prox_image`` is given, ``sigma_p`` is used instead of ``sigma_x`` in the reconstruction.
+        sigma_p (float, optional): [Default=None] Proximal map regularization parameter.
+            If None, automatically set with ``cone3D.auto_sigma_p`` as a function of ``sharpness``.
+            Ignored if ``prox_image`` is None.
+        p (float, optional): [Default=1.2] Scalar value in range :math:`[1,2]` that specifies qGGMRF shape parameter.
+        q (float, optional): [Default=2.0] Scalar value in range :math:`[p,1]` that specifies qGGMRF shape parameter.
+        T (float, optional): [Default=1.0] Scalar value :math:`>0` that specifies the qGGMRF threshold parameter.
+        num_neighbors (int, optional): [Default=6] Possible values are :math:`{26,18,6}`.
+            Number of neighbors in the qGGMRF neighborhood. More neighbors results in a better
+            regularization but a slower reconstruction.
+
+        sharpness (float, optional): [Default=0.0] Sharpness of reconstruction.
+            ``sharpness=0.0`` is neutral; ``sharpness>0`` increases sharpness; ``sharpness<0`` reduces sharpness.
+            Used to calculate ``sigma_x`` and ``sigma_p``.
+            Ignored if ``sigma_x`` is not None in qGGMRF mode, or if ``sigma_p`` is not None in proximal map mode.
+        positivity (bool, optional): [Default=True] Determines if positivity constraint will be enforced.
+        max_resolutions (int, optional): [Default=None] Integer :math:`\geq 0` that specifies the maximum number of grid
+            resolutions used to solve MBIR reconstruction problem.
+            If None, automatically set by ``cone3D.auto_max_resolutions``.
+        stop_threshold (float, optional): [Default=0.02] Relative update stopping threshold, in percent, where relative
+            update is given by (average value change) / (average voxel value).
+        max_iterations (int, optional): [Default=100] Maximum number of iterations before stopping.
+
+        NHICD (bool, optional): [Default=False] If True, uses non-homogeneous ICD updates.
+        num_threads (int, optional): [Default=None] Number of compute threads requested when executed.
+            If None, this is set to the number of cores in the system.
+        verbose (int, optional): [Default=1] Possible values are {0,1,2}, where 0 is quiet, 1 prints minimal
+            reconstruction progress information, and 2 prints the full information.
+        lib_path (str, optional): [Default=~/.cache/mbircone] Path to directory containing library of
+            forward projection matrices.
+
+    Returns:
+        (float, ndarray): 3D laminography reconstruction image with shape (num_img_slices, num_img_rows, num_img_cols)
+        in units of :math:`ALU^{-1}`.
+    """
+
+    (_, num_det_rows, num_det_channels) = sino.shape
+
+    (delta_det_channel, delta_det_row) = cone3D.auto_delta_det_channel_row(delta_det_channel, delta_det_row)
+
+    lamino_dist_source_detector, lamino_magnification, lamino_delta_det_row, lamino_det_row_offset, \
+        lamino_rotation_offset, lamino_image_slice_offset = auto_lamino_params(theta, num_det_rows, num_det_channels,
+                                                                               delta_det_channel, delta_det_row,
+                                                                               image_slice_offset)
+
+    # Translate laminography geometry to cone-beam approximation of laminography
+    return cone3D.recon(sino, angles, dist_source_detector=lamino_dist_source_detector,
+                        magnification=lamino_magnification,
+                        weights=weights, weight_type=weight_type, init_image=init_image, prox_image=prox_image,
+                        num_image_rows=num_image_rows, num_image_cols=num_image_cols,
+                        num_image_slices=num_image_slices,
+                        delta_det_channel=delta_det_channel, delta_det_row=lamino_delta_det_row,
+                        delta_pixel_image=delta_pixel_image,
+                        det_channel_offset=det_channel_offset, det_row_offset=lamino_det_row_offset,
+                        rotation_offset=lamino_rotation_offset, image_slice_offset=lamino_image_slice_offset,
+                        sigma_y=sigma_y, snr_db=snr_db, sigma_x=sigma_x, sigma_p=sigma_p, p=p, q=q, T=T,
+                        num_neighbors=num_neighbors,
+                        sharpness=sharpness, positivity=positivity, max_resolutions=max_resolutions,
+                        stop_threshold=stop_threshold, max_iterations=max_iterations,
+                        NHICD=NHICD, num_threads=num_threads, verbose=verbose, lib_path=lib_path)
+
+
+def project_lamino(image, angles, theta,
+                   num_det_rows, num_det_channels,
+                   delta_det_channel=None, delta_det_row=None, delta_pixel_image=None,
+                   det_channel_offset=0.0, image_slice_offset=0.0,
+                   num_threads=None, verbose=1, lib_path=__lib_path):
+    """ Compute 3D cone beam forward projection for the laminography case.
+
+    Args:
+        image (float, ndarray): 3D image to be projected, with shape (num_img_slices, num_img_rows, num_img_cols).
+        angles (float, ndarray): 1D array of view angles in radians.
+        theta (float): Angle that source-detector line makes with the object vertical axis.
+
+        num_det_rows (int): Number of rows in laminography sinogram data.
+        num_det_channels (int): Number of channels in laminography sinogram data.
+
+        delta_det_channel (float, optional): [Default=1.0] Detector channel spacing in :math:`ALU`. If None, set to
+            value of delta_det_row. If delta_det_row is None, set both to 1.0.
+        delta_det_row (float, optional): [Default=1.0] Detector row spacing in :math:`ALU`. If None, set to
+            value of delta_det_channel. If delta_det_channel is None, set both to 1.0.
+        delta_pixel_image (float, optional): [Default=None] Image pixel spacing in :math:`ALU`.
+            If None, automatically set to ``delta_det_channel/magnification``.
+
+        det_channel_offset (float, optional): [Default=0.0] Distance in :math:`ALU` from center of detector
+            to the detector z-axis along a row. (Note: There is no ``det_row_offset`` parameter; due to the
+            parallel beam geometry such a parameter would not have an effect.)
+        image_slice_offset (float, optional): [Default=0.0] Vertical offset of the image in units of :math:`ALU`.
+
+        num_threads (int, optional): [Default=None] Number of compute threads requested when executed.
+            If None, ``num_threads`` is set to the number of cores in the system.
+        verbose (int, optional): [Default=1] Possible values are {0,1,2}, where 0 is quiet, 1 prints minimal
+            reconstruction progress information, and 2 prints the full information.
+        lib_path (str, optional): [Default=~/.cache/mbircone] Path to directory containing library of
+            forward projection matrices.
+
+    Returns:
+        (float, ndarray): 3D laminography sinogram with shape (num_views, num_det_rows, num_det_channels).
+    """
+
+    (delta_det_channel, delta_det_row) = cone3D.auto_delta_det_channel_row(delta_det_channel, delta_det_row)
+
+    lamino_dist_source_detector, lamino_magnification, lamino_delta_det_row, lamino_det_row_offset, \
+        lamino_rotation_offset, lamino_image_slice_offset = auto_lamino_params(theta, num_det_rows, num_det_channels,
+                                                                               delta_det_channel, delta_det_row,
+                                                                               image_slice_offset)
+
+    return cone3D.project(image=image, angles=angles,
+                          num_det_rows=num_det_rows, num_det_channels=num_det_channels,
+                          dist_source_detector=lamino_dist_source_detector, magnification=lamino_magnification,
+                          delta_det_channel=delta_det_channel, delta_det_row=lamino_delta_det_row,
+                          delta_pixel_image=delta_pixel_image,
+                          det_channel_offset=det_channel_offset, det_row_offset=lamino_det_row_offset,
+                          rotation_offset=lamino_rotation_offset,
+                          image_slice_offset=lamino_image_slice_offset,
+                          num_threads=num_threads, verbose=verbose, lib_path=lib_path)
+
+

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -1,10 +1,11 @@
 import numpy as np
 
-def gen_shepp_logan(num_rows,num_cols):
+
+def gen_shepp_logan(num_rows, num_cols):
     """
     Generate a Shepp Logan phantom
-    
-    Args: 
+
+    Args:
         num_rows: int, number of rows.
         num_cols: int, number of cols.
 
@@ -34,8 +35,8 @@ def gen_shepp_logan(num_rows,num_cols):
 
     for el_paras in sl_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                             gray_level=el_paras['gray_level'])
+                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                              gray_level=el_paras['gray_level'])
 
     return image
 
@@ -66,18 +67,19 @@ def gen_microscopy_sample(num_rows, num_cols):
     axis_x = np.linspace(-1, 1, num_cols)
     axis_y = np.linspace(2, -2, num_rows)
 
-    x_grid, y_grid = np.meshgrid(axis_x, axis_y )
+    x_grid, y_grid = np.meshgrid(axis_x, axis_y)
     image = x_grid * 0.0
 
     for el_paras in ms_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                             gray_level=el_paras['gray_level'])
+                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                              gray_level=el_paras['gray_level'])
 
     return image
 
 
-def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2,2,2), scale=1.0, offset_x=0.0, offset_y=0.0, offset_z=0.0):
+def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2, 2, 2), scale=1.0, offset_x=0.0, offset_y=0.0,
+                       offset_z=0.0):
     """
     Generate a 3D Shepp Logan phantom.
     Optional arguments can be used to control the scale and position,
@@ -98,25 +100,26 @@ def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2,2,2), scale
         out_image: 3D array, num_slices*num_rows*num_cols
     """
 
-    phantom_raw = gen_shepp_logan_3d_raw(num_rows*block_size[1], num_cols*block_size[2], num_slices*block_size[0],
+    phantom_raw = gen_shepp_logan_3d_raw(num_rows * block_size[1], num_cols * block_size[2], num_slices * block_size[0],
                                          scale=scale, offset_x=offset_x, offset_y=offset_y, offset_z=offset_z)
-    phantom = phantom_raw.reshape(phantom_raw.shape[0]//block_size[0], block_size[0], 
-                                  phantom_raw.shape[1]//block_size[1], block_size[1],
-                                  phantom_raw.shape[2]//block_size[2], block_size[2]).sum((1, 3, 5)) / (block_size[0]*block_size[1]*block_size[2])
+    phantom = phantom_raw.reshape(phantom_raw.shape[0] // block_size[0], block_size[0],
+                                  phantom_raw.shape[1] // block_size[1], block_size[1],
+                                  phantom_raw.shape[2] // block_size[2], block_size[2]).sum((1, 3, 5)) / (
+                          block_size[0] * block_size[1] * block_size[2])
     return phantom
 
 
 def gen_shepp_logan_3d_raw(num_rows, num_cols, num_slices, scale=1.0, offset_x=0.0, offset_y=0.0, offset_z=0.0):
     """
     Generate a 3D Shepp Logan phantom based on below reference.
-    
+
     Kak AC, Slaney M. Principles of computerized tomographic imaging. Page.102. IEEE Press, New York, 1988. https://engineering.purdue.edu/~malcolm/pct/CTI_Ch03.pdf
 
     Args:
         num_rows: int, number of rows.
         num_cols: int, number of cols.
         num_slices: int, number of slices.
-        
+
         scale: (scalar, optional), scaling factor of phantom within the image. from 0 to 1
         offset_x: scalar, proportion of x-axis that is added to x-coordinate of phantom within image
         offset_y: scalar, proportion of y-axis that is added to y-coordinate of phantom within image
@@ -152,13 +155,12 @@ def gen_shepp_logan_3d_raw(num_rows, num_cols, num_slices, scale=1.0, offset_x=0
     shift_z = offset_z * 2.0
 
     for el_paras in sl3d_paras:
-        image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0']*scale - shift_x, y0=el_paras['y0']*scale - shift_y,
-                               z0=el_paras['z0']*scale - shift_z,
-                               a=el_paras['a']*scale, b=el_paras['b']*scale, c=el_paras['c']*scale,
-                               gamma=el_paras['gamma'] / 180.0 * np.pi,
-                               gray_level=el_paras['gray_level'])
-
-    
+        image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0'] * scale - shift_x,
+                                y0=el_paras['y0'] * scale - shift_y,
+                                z0=el_paras['z0'] * scale - shift_z,
+                                a=el_paras['a'] * scale, b=el_paras['b'] * scale, c=el_paras['c'] * scale,
+                                gamma=el_paras['gamma'] / 180.0 * np.pi,
+                                gray_level=el_paras['gray_level'])
 
     return np.transpose(image, (2, 0, 1))
 
@@ -178,14 +180,14 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     # The function describing the phantom is defined as the sum of 8 ellipsoids inside a 2×4×2 cuboid:
     ms3d_paras = [
-        {'x0': 0.0, 'y0': -0.0184, 'z0':0.0, 'a': 0.6624, 'b': 1.748, 'c':0.8, 'gamma': 0, 'gray_level': 0.2},
-        {'x0': -0.1, 'y0': 1.343, 'z0':0.0, 'a': 0.11, 'b': 0.10, 'c':0.20, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': 0.0, 'y0': 0.9, 'z0':0.0, 'a': 0.33, 'b': 0.15, 'c':0.66, 'gamma': 0, 'gray_level': 0.4},
-        {'x0': 0.25, 'y0': 0.4, 'z0':0.0, 'a': 0.1, 'b': 0.2, 'c':0.40, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': -0.2, 'y0': 0.0, 'z0':0.0, 'a': 0.2, 'b': 0.08, 'c':0.40, 'gamma': 0, 'gray_level': 0.4},
-        {'x0': 0.2, 'y0': -0.35, 'z0':0.0, 'a': 0.1, 'b': 0.1, 'c':0.2, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': 0.25, 'y0': -0.8, 'z0':0.0, 'a': 0.2, 'b': 0.08, 'c':0.4, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': -0.04, 'y0': -1.3, 'z0':0.0, 'a': 0.33, 'b': 0.15, 'c':0.30, 'gamma': 0, 'gray_level': 0.8}
+        {'x0': 0.0, 'y0': -0.0184, 'z0': 0.0, 'a': 0.6624, 'b': 1.748, 'c': 0.8, 'gamma': 0, 'gray_level': 0.2},
+        {'x0': -0.1, 'y0': 1.343, 'z0': 0.0, 'a': 0.11, 'b': 0.10, 'c': 0.20, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': 0.0, 'y0': 0.9, 'z0': 0.0, 'a': 0.33, 'b': 0.15, 'c': 0.66, 'gamma': 0, 'gray_level': 0.4},
+        {'x0': 0.25, 'y0': 0.4, 'z0': 0.0, 'a': 0.1, 'b': 0.2, 'c': 0.40, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': -0.2, 'y0': 0.0, 'z0': 0.0, 'a': 0.2, 'b': 0.08, 'c': 0.40, 'gamma': 0, 'gray_level': 0.4},
+        {'x0': 0.2, 'y0': -0.35, 'z0': 0.0, 'a': 0.1, 'b': 0.1, 'c': 0.2, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': 0.25, 'y0': -0.8, 'z0': 0.0, 'a': 0.2, 'b': 0.08, 'c': 0.4, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': -0.04, 'y0': -1.3, 'z0': 0.0, 'a': 0.33, 'b': 0.15, 'c': 0.30, 'gamma': 0, 'gray_level': 0.8}
     ]
 
     axis_x = np.linspace(-1.0, 1.0, num_cols)
@@ -197,12 +199,72 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     for el_paras in ms3d_paras:
         image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                               z0=el_paras['z0'],
-                               a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
-                               gamma=el_paras['gamma'] / 180.0 * np.pi,
-                               gray_level=el_paras['gray_level'])
+                                z0=el_paras['z0'],
+                                a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
+                                gamma=el_paras['gamma'] / 180.0 * np.pi,
+                                gray_level=el_paras['gray_level'])
 
     return np.transpose(image, (2, 0, 1))
+
+
+def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0):
+    """
+    Generate a 3D laminography phantom by extracting a rectangular region
+    from a 3D microscopy sample phantom.
+    Args:
+        num_rows: int, number of rows.
+        num_cols: int, number of cols.
+        num_slices: int, number of slices.
+        pad_factor (float, optional): [Default=0] Size of constant padding around
+            phantom rows and columns to simulate a flat object.
+            Value is given as a multiple of the size of the phantom.
+    Return:
+        out_image: 3D array, num_slices*num_rows*num_cols
+    """
+
+    # Proportion of the microscopy sample that the laminography sample should be
+    proportion_of_microscopy = .54
+
+    num_slices_base = int(num_slices / proportion_of_microscopy)
+    num_rows_base = int(num_rows / proportion_of_microscopy)
+    num_cols_base = int(num_cols / proportion_of_microscopy)
+
+    phantom = gen_microscopy_sample_3d(num_rows_base, num_cols_base, num_slices_base)
+
+    slice_start = (num_slices_base - num_slices) // 2
+    slice_end = (num_slices_base + num_slices) // 2
+    row_start = (num_rows_base - num_rows) // 2
+    row_end = (num_rows_base + num_rows) // 2
+    col_start = (num_cols_base - num_cols) // 2
+    col_end = (num_cols_base + num_cols) // 2
+
+    phantom = phantom[slice_start:slice_end, row_start:row_end, col_start:col_end]
+
+    phantom = np.clip(phantom, 0.2, 2.0)
+
+    # if edge_pixel_thickness <= 0:
+    #     return phantom
+    #
+    # phantom[:edge_pixel_thickness] = 2.0
+    # phantom[-edge_pixel_thickness:] = 2.0
+    # phantom[:, :edge_pixel_thickness] = 2.0
+    # phantom[:, -edge_pixel_thickness:] = 2.0
+    # phantom[:, :, :edge_pixel_thickness] = 2.0
+    # phantom[:, :, -edge_pixel_thickness:] = 2.0
+
+    # Pad phantom so that the edges are replicated
+    pad_rows_l = num_rows * pad_factor
+    pad_rows_r = pad_rows_l
+    pad_cols_l = num_cols * pad_factor
+    pad_cols_r = pad_cols_l
+    pad_slices_l = num_slices * pad_factor
+    pad_slices_r = pad_slices_l
+
+    phantom = np.pad(phantom, [(0, 0), (pad_rows_l, pad_rows_r), (pad_cols_l, pad_cols_r)], mode='edge')
+    phantom = np.pad(phantom, [(pad_slices_l, pad_slices_r), (0, 0), (0, 0)], mode='constant', constant_values=0.0)
+
+    return phantom
+
 
 def nrmse(image, reference_image):
     """
@@ -219,7 +281,7 @@ def nrmse(image, reference_image):
     rmse = np.sqrt(((image - reference_image) ** 2).mean())
     denominator = np.sqrt(((reference_image) ** 2).mean())
 
-    return rmse/denominator
+    return rmse / denominator
 
 
 def _gen_ellipse(x_grid, y_grid, x0, y0, a, b, gray_level, theta=0):

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -205,7 +205,7 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
     return np.transpose(image, (2, 0, 1))
 
 
-def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0):
+def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0.0):
     """
     Generate a 3D laminography phantom by extracting a rectangular region
     from a 3D microscopy sample phantom.
@@ -213,7 +213,7 @@ def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0):
         num_rows: int, number of rows.
         num_cols: int, number of cols.
         num_slices: int, number of slices.
-        pad_factor (float, optional): [Default=0] Size of constant padding around
+        pad_factor (float, optional): [Default=0.0] Size of constant padding around
             phantom rows and columns to simulate a flat object.
             Value is given as a multiple of the size of the phantom.
     Return:
@@ -239,16 +239,6 @@ def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0):
     phantom = phantom[slice_start:slice_end, row_start:row_end, col_start:col_end]
 
     phantom = np.clip(phantom, 0.2, 2.0)
-
-    # if edge_pixel_thickness <= 0:
-    #     return phantom
-    #
-    # phantom[:edge_pixel_thickness] = 2.0
-    # phantom[-edge_pixel_thickness:] = 2.0
-    # phantom[:, :edge_pixel_thickness] = 2.0
-    # phantom[:, -edge_pixel_thickness:] = 2.0
-    # phantom[:, :, :edge_pixel_thickness] = 2.0
-    # phantom[:, :, -edge_pixel_thickness:] = 2.0
 
     # Pad phantom so that the edges are replicated
     pad_rows_l = num_rows * pad_factor

--- a/mbircone/phantom.py
+++ b/mbircone/phantom.py
@@ -1,11 +1,10 @@
 import numpy as np
 
-
-def gen_shepp_logan(num_rows, num_cols):
+def gen_shepp_logan(num_rows,num_cols):
     """
     Generate a Shepp Logan phantom
-
-    Args:
+    
+    Args: 
         num_rows: int, number of rows.
         num_cols: int, number of cols.
 
@@ -35,8 +34,8 @@ def gen_shepp_logan(num_rows, num_cols):
 
     for el_paras in sl_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                              gray_level=el_paras['gray_level'])
+                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                             gray_level=el_paras['gray_level'])
 
     return image
 
@@ -67,19 +66,18 @@ def gen_microscopy_sample(num_rows, num_cols):
     axis_x = np.linspace(-1, 1, num_cols)
     axis_y = np.linspace(2, -2, num_rows)
 
-    x_grid, y_grid = np.meshgrid(axis_x, axis_y)
+    x_grid, y_grid = np.meshgrid(axis_x, axis_y )
     image = x_grid * 0.0
 
     for el_paras in ms_paras:
         image += _gen_ellipse(x_grid=x_grid, y_grid=y_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                              a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
-                              gray_level=el_paras['gray_level'])
+                             a=el_paras['a'], b=el_paras['b'], theta=el_paras['theta'] / 180.0 * np.pi,
+                             gray_level=el_paras['gray_level'])
 
     return image
 
 
-def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2, 2, 2), scale=1.0, offset_x=0.0, offset_y=0.0,
-                       offset_z=0.0):
+def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2,2,2), scale=1.0, offset_x=0.0, offset_y=0.0, offset_z=0.0):
     """
     Generate a 3D Shepp Logan phantom.
     Optional arguments can be used to control the scale and position,
@@ -100,26 +98,25 @@ def gen_shepp_logan_3d(num_rows, num_cols, num_slices, block_size=(2, 2, 2), sca
         out_image: 3D array, num_slices*num_rows*num_cols
     """
 
-    phantom_raw = gen_shepp_logan_3d_raw(num_rows * block_size[1], num_cols * block_size[2], num_slices * block_size[0],
+    phantom_raw = gen_shepp_logan_3d_raw(num_rows*block_size[1], num_cols*block_size[2], num_slices*block_size[0],
                                          scale=scale, offset_x=offset_x, offset_y=offset_y, offset_z=offset_z)
-    phantom = phantom_raw.reshape(phantom_raw.shape[0] // block_size[0], block_size[0],
-                                  phantom_raw.shape[1] // block_size[1], block_size[1],
-                                  phantom_raw.shape[2] // block_size[2], block_size[2]).sum((1, 3, 5)) / (
-                          block_size[0] * block_size[1] * block_size[2])
+    phantom = phantom_raw.reshape(phantom_raw.shape[0]//block_size[0], block_size[0], 
+                                  phantom_raw.shape[1]//block_size[1], block_size[1],
+                                  phantom_raw.shape[2]//block_size[2], block_size[2]).sum((1, 3, 5)) / (block_size[0]*block_size[1]*block_size[2])
     return phantom
 
 
 def gen_shepp_logan_3d_raw(num_rows, num_cols, num_slices, scale=1.0, offset_x=0.0, offset_y=0.0, offset_z=0.0):
     """
     Generate a 3D Shepp Logan phantom based on below reference.
-
+    
     Kak AC, Slaney M. Principles of computerized tomographic imaging. Page.102. IEEE Press, New York, 1988. https://engineering.purdue.edu/~malcolm/pct/CTI_Ch03.pdf
 
     Args:
         num_rows: int, number of rows.
         num_cols: int, number of cols.
         num_slices: int, number of slices.
-
+        
         scale: (scalar, optional), scaling factor of phantom within the image. from 0 to 1
         offset_x: scalar, proportion of x-axis that is added to x-coordinate of phantom within image
         offset_y: scalar, proportion of y-axis that is added to y-coordinate of phantom within image
@@ -155,12 +152,13 @@ def gen_shepp_logan_3d_raw(num_rows, num_cols, num_slices, scale=1.0, offset_x=0
     shift_z = offset_z * 2.0
 
     for el_paras in sl3d_paras:
-        image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0'] * scale - shift_x,
-                                y0=el_paras['y0'] * scale - shift_y,
-                                z0=el_paras['z0'] * scale - shift_z,
-                                a=el_paras['a'] * scale, b=el_paras['b'] * scale, c=el_paras['c'] * scale,
-                                gamma=el_paras['gamma'] / 180.0 * np.pi,
-                                gray_level=el_paras['gray_level'])
+        image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0']*scale - shift_x, y0=el_paras['y0']*scale - shift_y,
+                               z0=el_paras['z0']*scale - shift_z,
+                               a=el_paras['a']*scale, b=el_paras['b']*scale, c=el_paras['c']*scale,
+                               gamma=el_paras['gamma'] / 180.0 * np.pi,
+                               gray_level=el_paras['gray_level'])
+
+    
 
     return np.transpose(image, (2, 0, 1))
 
@@ -180,14 +178,14 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     # The function describing the phantom is defined as the sum of 8 ellipsoids inside a 2×4×2 cuboid:
     ms3d_paras = [
-        {'x0': 0.0, 'y0': -0.0184, 'z0': 0.0, 'a': 0.6624, 'b': 1.748, 'c': 0.8, 'gamma': 0, 'gray_level': 0.2},
-        {'x0': -0.1, 'y0': 1.343, 'z0': 0.0, 'a': 0.11, 'b': 0.10, 'c': 0.20, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': 0.0, 'y0': 0.9, 'z0': 0.0, 'a': 0.33, 'b': 0.15, 'c': 0.66, 'gamma': 0, 'gray_level': 0.4},
-        {'x0': 0.25, 'y0': 0.4, 'z0': 0.0, 'a': 0.1, 'b': 0.2, 'c': 0.40, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': -0.2, 'y0': 0.0, 'z0': 0.0, 'a': 0.2, 'b': 0.08, 'c': 0.40, 'gamma': 0, 'gray_level': 0.4},
-        {'x0': 0.2, 'y0': -0.35, 'z0': 0.0, 'a': 0.1, 'b': 0.1, 'c': 0.2, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': 0.25, 'y0': -0.8, 'z0': 0.0, 'a': 0.2, 'b': 0.08, 'c': 0.4, 'gamma': 0, 'gray_level': 0.8},
-        {'x0': -0.04, 'y0': -1.3, 'z0': 0.0, 'a': 0.33, 'b': 0.15, 'c': 0.30, 'gamma': 0, 'gray_level': 0.8}
+        {'x0': 0.0, 'y0': -0.0184, 'z0':0.0, 'a': 0.6624, 'b': 1.748, 'c':0.8, 'gamma': 0, 'gray_level': 0.2},
+        {'x0': -0.1, 'y0': 1.343, 'z0':0.0, 'a': 0.11, 'b': 0.10, 'c':0.20, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': 0.0, 'y0': 0.9, 'z0':0.0, 'a': 0.33, 'b': 0.15, 'c':0.66, 'gamma': 0, 'gray_level': 0.4},
+        {'x0': 0.25, 'y0': 0.4, 'z0':0.0, 'a': 0.1, 'b': 0.2, 'c':0.40, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': -0.2, 'y0': 0.0, 'z0':0.0, 'a': 0.2, 'b': 0.08, 'c':0.40, 'gamma': 0, 'gray_level': 0.4},
+        {'x0': 0.2, 'y0': -0.35, 'z0':0.0, 'a': 0.1, 'b': 0.1, 'c':0.2, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': 0.25, 'y0': -0.8, 'z0':0.0, 'a': 0.2, 'b': 0.08, 'c':0.4, 'gamma': 0, 'gray_level': 0.8},
+        {'x0': -0.04, 'y0': -1.3, 'z0':0.0, 'a': 0.33, 'b': 0.15, 'c':0.30, 'gamma': 0, 'gray_level': 0.8}
     ]
 
     axis_x = np.linspace(-1.0, 1.0, num_cols)
@@ -199,10 +197,10 @@ def gen_microscopy_sample_3d(num_rows, num_cols, num_slices):
 
     for el_paras in ms3d_paras:
         image += _gen_ellipsoid(x_grid=x_grid, y_grid=y_grid, z_grid=z_grid, x0=el_paras['x0'], y0=el_paras['y0'],
-                                z0=el_paras['z0'],
-                                a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
-                                gamma=el_paras['gamma'] / 180.0 * np.pi,
-                                gray_level=el_paras['gray_level'])
+                               z0=el_paras['z0'],
+                               a=el_paras['a'], b=el_paras['b'], c=el_paras['c'],
+                               gamma=el_paras['gamma'] / 180.0 * np.pi,
+                               gray_level=el_paras['gray_level'])
 
     return np.transpose(image, (2, 0, 1))
 
@@ -265,7 +263,6 @@ def gen_lamino_sample_3d(num_rows, num_cols, num_slices, pad_factor=0):
 
     return phantom
 
-
 def nrmse(image, reference_image):
     """
     Compute the normalized root mean square error between image and reference_image.
@@ -281,7 +278,7 @@ def nrmse(image, reference_image):
     rmse = np.sqrt(((image - reference_image) ** 2).mean())
     denominator = np.sqrt(((reference_image) ** 2).mean())
 
-    return rmse / denominator
+    return rmse/denominator
 
 
 def _gen_ellipse(x_grid, y_grid, x0, y0, a, b, gray_level, theta=0):


### PR DESCRIPTION
This pull request is an implementation of laminography as a wrapper over the current master branch of mbircone.

This pull request includes the following changes:

- Add the following files:
    - mbircone/laminography.py
    - docs/source/laminography.rst
    - demo/demo_laminography.py
- Modify the following files:
    - mbircone/\_\_init\_\_.py
        - add import statement for laminography module
    - mbircone/phantom.py
        - add method `gen_lamino_sample_3d`
    - docs/source/api.rst
        - add laminography tags to api file

The following slides document testing of the laminography module, and correspond to the tests found [here](https://github.com/bommaritom/mbircone/tree/test/lamino_features):
[Tests-Laminography.pptx](https://github.com/cabouman/mbircone/files/10710290/Tests-Laminography.pptx)



The following demo files have been tested:
- demo_3D_shepp_logan.py
- demo_laminography.py