### PR TITLE
detector row offset calculation

### DIFF
--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -339,7 +339,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
         # counter-clockwise rotation
         angle_step = -angle_step
     v_d0 = - v_d1
-    w_d0 = - geo_params['num_det_rows'] * geo_params['delta_det_row'] / 2.0
+    w_d0 = - w_d1
     geo_params['rotation_offset'] = 0.0
 
     ############### Adjust geometry NSI_params according to crop_factor and downsample_factor


### PR DESCRIPTION
This pull request fixes the det_row_offset calculation in NSI preprocess function.
The fix is only one line of code :-)

Results of `demo_nsi_preprocess.py` before & after the fix:

before (det_row_offset=0):
![recon_coronal187](https://user-images.githubusercontent.com/7671736/227601753-1c6109fb-33f2-40d2-af5e-8008a70ecb65.png)

after (det_row_offset=1.15):
![recon_coronal187](https://user-images.githubusercontent.com/7671736/227601775-127ac2cb-43cf-4cbb-90f5-a69145927ea7.png)

The results are visually similar before & after because the row offset is small.

Also tested the code with the tin-filtered dataset, which has a larger row_offset=16.76. It yields a clear reconstruction without misalignment artifacts.