### PR TITLE
Background offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__
 # docs
 docs/build/
 
+*.swp
+
 # compiled files
 mbircone/*.c
 mbircone/*.so
@@ -31,6 +33,7 @@ sftp-config.json
 
 # Personal files
 test/output/*
+test/demo_data/*
 demo/configs
 demo/demo_data/*
 demo/output/*

--- a/docs/source/preprocess.rst
+++ b/docs/source/preprocess.rst
@@ -11,3 +11,4 @@ mbircone.preprocess
 
       NSI_load_scans_and_params
       transmission_CT_preprocess
+      calc_background_offset

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -460,7 +460,7 @@ def calc_background_offset(sino, option=0, edge_width=9):
     Args:
         sino (float, ndarray): Sinogram data with 3D shape (num_views, num_det_rows, num_det_channels).
         option (int, optional): [Default=0] Option of algorithm used to calculate the background offset.
-        edge_width(int, optional): [Default=3] Width of the edge regions in pixels. It must be an odd integer >= 3.
+        edge_width(int, optional): [Default=9] Width of the edge regions in pixels. It must be an odd integer >= 3.
     Returns:
         offset (float): Background offset value.
     """

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -452,15 +452,11 @@ def transmission_CT_preprocess(obj_scan, blank_scan, dark_scan,
     return sino.astype(np.float32), weights.astype(np.float32)
 
 
-def calc_background_offset(sino, option=0, edge_width=3):
-    """ Given the sinogram data, automatically calculate the background offset based on the selected option. Available options are:
+def calc_background_offset(sino, option=0, edge_width=9):
+    """ Given a sinogram, automatically calculate the background offset based on the selected option. Available options are:
 
-        **Option 0**: Calculate the background offset based on the background region in the corner of the sinogram images. This is done with the following steps:
+        **Option 0**: Calculate the background offset using edge_width pixels along the upper, left, and right edges of an average sinogram view.
 
-            1. Calculate the mean sinogram image across all views: ``sino_mean=np.mean(sino, axis=0)``.
-            2. Select three background regions from the top, left, and right edges of the mean sinogram image.
-            3. For each background region, calculate its background value as: offset = median([median value of each line in the edge region]). 
-            4. The background offset value is selected as the median of the three offset values from different edge regions. 
     Args:
         sino (float, ndarray): Sinogram data with 3D shape (num_views, num_det_rows, num_det_channels).
         option (int, optional): [Default=0] Option of algorithm used to calculate the background offset.

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -455,7 +455,7 @@ def transmission_CT_preprocess(obj_scan, blank_scan, dark_scan,
 def calc_background_offset(sino, option=0, edge_width=9):
     """ Given a sinogram, automatically calculate the background offset based on the selected option. Available options are:
 
-        **Option 0**: Calculate the background offset using edge_width pixels along the upper, left, and right edges of an average sinogram view.
+        **Option 0**: Calculate the background offset using edge_width pixels along the upper, left, and right edges of a median sinogram view.
 
     Args:
         sino (float, ndarray): Sinogram data with 3D shape (num_views, num_det_rows, num_det_channels).
@@ -478,19 +478,19 @@ def calc_background_offset(sino, option=0, edge_width=9):
     _, _, num_det_channels = sino.shape
 
     # calculate mean sinogram
-    sino_mean=np.mean(sino, axis=0)
+    sino_median=np.median(sino, axis=0)
 
     # offset value of the top edge region.
     # Calculated as median([median value of each horizontal line in top edge region])
-    median_top = np.median(np.median(sino_mean[:edge_width], axis=1))
+    median_top = np.median(np.median(sino_median[:edge_width], axis=1))
 
     # offset value of the left edge region.
     # Calculated as median([median value of each vertical line in left edge region])
-    median_left = np.median(np.median(sino_mean[:, :edge_width], axis=0))
+    median_left = np.median(np.median(sino_median[:, :edge_width], axis=0))
 
     # offset value of the right edge region.
     # Calculated as median([median value of each vertical line in right edge region])
-    median_right = np.median(np.median(sino_mean[:, num_det_channels-edge_width:], axis=0))
+    median_right = np.median(np.median(sino_median[:, num_det_channels-edge_width:], axis=0))
 
     # offset = median of three offset values from top, left, right edge regions.
     offset = np.median([median_top, median_left, median_right])

--- a/mbircone/src/interface.c
+++ b/mbircone/src/interface.c
@@ -109,7 +109,7 @@ void recon(float *x, float *y, float *wght, float *proxmap_input,
     if(proxmap_input == x)
     {
         img.proxMapInput = (float *) mget_spc((size_t)img.params.N_x*img.params.N_y*img.params.N_z,sizeof(float));
-        for(i=0; i<(size_t)img.params.N_x*img.params.N_y*img.params.N_z; i++)
+        for(i=0; i<(int)img.params.N_x*img.params.N_y*img.params.N_z; i++)
             img.proxMapInput[i] = proxmap_input[i];
     }
     else

--- a/test/test_background_offset.py
+++ b/test/test_background_offset.py
@@ -76,7 +76,7 @@ print('sino shape = ', sino.shape)
 print("\n*******************************************************",
       "\n*********** Calculating background offset *************",
       "\n*******************************************************")
-edge_width = 9
+edge_width = 9 # same as default value in calc_background_offset()
 background_offset = mbircone.preprocess.calc_background_offset(sino, edge_width=edge_width)
 print("Calculated background offset = ", background_offset)
 
@@ -90,15 +90,11 @@ imgplot = plt.imshow(sino[0], vmin=-0.1, vmax=0.1, interpolation='none')
 plt.title(label="sinogram view with background region information")
 imgplot.set_cmap('gray')
 plt.colorbar()
+
 # overlay background region on top of the sinogram plot 
-background_info_list = [(0,0,num_det_channels,edge_width), # top edge region: (x,y,width,height)
-                        (0,0,edge_width,num_det_rows),     # left edge region
-                        (num_det_channels-edge_width,0,edge_width,num_det_rows)]     # right edge region
-for background_info in background_info_list:
-    (x,y,width,height) = background_info
-    rect = patches.Rectangle((x, y), width, height, linewidth=1, edgecolor='r', facecolor='none')
-    # Add the patch to the Axes
-    plt.gca().add_patch(rect)
+plt.axhline(y=edge_width, color="r") # top edge region
+plt.axvline(x=edge_width, color="r") # left edge region
+plt.axvline(x=num_det_channels-edge_width, color="r") # right edge region
 plt.title(label=f"sinogram view 0. Background offset = {background_offset:.6f}")
 plt.savefig(os.path.join(save_path, "background_region_info.png"))
 


### PR DESCRIPTION
This is a pull request to merge background offset correction into master.

Compared to the previous PR, this PR makes the following changes:

1. Use the median sinogram view instead of the mean sinogram view.
2. Modified the script `test_background_offset.py` to include the following test results:
    a. Display the sinogram view before and after the offset correction. The purpose is to visually inspect that the background value after the correction is closer to 0.
    b. Plot the sinogram view with negative pixels marked in red. The purpose is to show that the area containing the object of interest has no negative pixels after the correction.
    c. Added a print message to show the number of negative pixels before and after the background correction.

3. Added a new test script `test_background_offset_with_recon.py`. The purpose is to perform thorough test of the background offset correction by comparing the recon results before & after the correction. Results are shown below:

Recon with original sinogram:
![recon_orig_sino_axial210](https://github.com/cabouman/mbircone/assets/7671736/2a332c89-1819-4bbb-9d5f-ee4541d72e86)

Recon with corrected sinogram:
![recon_corrected_sino_axial210](https://github.com/cabouman/mbircone/assets/7671736/034f5658-2925-4b73-a2a2-475c4aa2940b)

**The nubs on the top and bottom are better reconstructed with the corrected sinogram data.**