### PR TITLE
MAR docstring & interpolation method update

### DIFF
--- a/dev_scripts/reinstall_conda_environment.sh
+++ b/dev_scripts/reinstall_conda_environment.sh
@@ -2,11 +2,19 @@
 # This script destroys the conda environment named "mbircone" and recreates it.
 
 # Create and activate new conda environment
+# First check if the target environment is active and deactivate if so
+NAME=mbircone
+
+ENV_STRING=$((conda env list) | grep $NAME)
+if [[ $ENV_STRING == *$NAME* ]]; then
+  echo conda deactivate
+fi
 cd ..
-conda deactivate
-conda deactivate
+
+# Create and activate new conda environment
 conda remove env --name mbircone --all
 conda create --name mbircone python=3.8
 conda activate mbircone
+
 cd dev_scripts
 

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -72,8 +72,8 @@ where the metal components are identified from an ``init_recon`` with a ``metal_
 
 The weights are controlled by parameters :math:`\beta` and :math:`\gamma`. :math:`\beta>0` controls weight to sinogram entries with low photon counts, and :math:`\gamma \geq 1` controls weight to sinogram entries in which the projection paths contain metal components. 
 
-Increasing :math:`\beta` improves image homogeneity, but may result in more severe metal artifacts. Increasing :math:`\gamma` reduces image artifacts around metal regions, but may result in worse image quality inside the metal regions, as well as reduced image homogeneity.
-
+A larger :math:`\beta` improves the noise uniformity, but too large a value may increase the overall noise level. A larger :math:`\gamma` reduces the weight of sinogram entries with metal, but too large a value may reduce image quality inside the metal regions.
+ 
 Note that the case :math:`(\beta, \gamma)=(1.0, 1.0)` corresponds to ``weight_type`` = "transmission", and :math:`(\beta, \gamma)=(2.0, 1.0)` corresponds to ``weight_type`` = "transmission_root".
 
 These quantities correspond to the following python variables:

--- a/mbircone/_utils.py
+++ b/mbircone/_utils.py
@@ -7,7 +7,6 @@ import os
 import hashlib
 import random
 from PIL import Image
-from scipy.interpolate import RegularGridInterpolator
 
 def hash_params(angles, sinoparams, imgparams):
     hash_input = str(sinoparams) + str(imgparams) + str(np.around(angles, decimals=6))

--- a/mbircone/interface_cy_c.pyx
+++ b/mbircone/interface_cy_c.pyx
@@ -6,7 +6,7 @@ cimport cython          # Import cython package
 cimport numpy as cnp    # Import specialized cython support for numpy
 cimport openmp
 from libc.string cimport memset,strcpy
-from scipy.ndimage import zoom
+from skimage.transform import rescale
 import mbircone._utils as _utils
 
 __namelen_sysmatrix = 20
@@ -361,13 +361,13 @@ def recon_cy(sino, angles, wght, x_init, proxmap_input,
 
             # Reduce resolution of initialization image if there is one
             if isinstance(x_init, np.ndarray) and (x_init.ndim == 3):
-                lr_init_image = zoom(x_init, 0.5)
+                lr_init_image = rescale(x_init, scale=0.5, anti_aliasing=True)
             else:
                 lr_init_image = x_init
 
             # Reduce resolution of proximal image if there is one
             if isinstance(proxmap_input, np.ndarray) and (proxmap_input.ndim == 3):
-                lr_prox_image = zoom(proxmap_input, 0.5)
+                lr_prox_image = rescale(proxmap_input, scale=0.5, anti_aliasing=True)
             else:
                 lr_prox_image = proxmap_input
 
@@ -380,7 +380,7 @@ def recon_cy(sino, angles, wght, x_init, proxmap_input,
                                 num_threads, lib_path)
 
             # Interpolate resolution of reconstruction
-            x_init = zoom(lr_recon, 2.0)
+            x_init = rescale(lr_recon, scale=2.0)
             del lr_recon
             del lr_init_image
             del lr_prox_image

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -640,13 +640,10 @@ def calc_weights_mar(sino, angles, dist_source_detector, magnification,
     Optional arguments specific to MAR data weights:
         - **beta** (*float, optional*): [Default=2.0] Scalar value in range :math:`>0`.
 
-            ``beta`` controls the weight to sinogram entries with low photon counts.
-            A larger ``beta`` value improves image homogeneity, but may result in more severe metal artifacts.
-
+            A larger ``beta`` improves the noise uniformity, but too large a value may increase the overall noise level.
         - **gamma** (*float, optional*): [Default=4.0] Scalar value in range :math:`>1`.
 
-            ``gamma`` controls the weight to sinogram entries in which the projection paths contain metal components.
-            A larger ``gamma`` value reduces image artifacts around metal regions, but may result in worse image quality inside metal regions, as well as reduced image homogeneity.
+            A larger ``gamma`` reduces the weight of sinogram entries with metal, but too large a value may reduce image quality inside the metal regions.
         - **defective_pixel_list** (optional, list(tuple)): [Default=None] A list of tuples containing indices of invalid sinogram pixels, with the format (view_idx, row_idx, channel_idx).
 
             weights=0.0 for invalid sinogram entries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ psutil~=5.8.0
 Pillow>=9.1
 dask~=2022.4.1
 dask-jobqueue~=0.7.3
-scipy
 scikit-image


### PR DESCRIPTION
This PR contains two components:
1. Update the docstring of MAR weight as discussed yesterday:
![Screen Shot 2023-06-09 at 1 20 14 PM](https://github.com/cabouman/mbircone/assets/7671736/0156d9ec-f188-4cd0-b42c-7e09175df53d)

2. In multi resolution reconstruction, change the interpolation method from scipy.zoom() to skimage.rescale(), which yields a smoother interpolation with less high-frequency artifacts. 
    As we observed last week, this results in **faster convergence** of the 3D shepp Logan problem (highest resolution recon: **18 iterations -> 15 iterations**) without sacrificing image quality.
    This also reduces the software dependency. The mbircone source code does not require scipy anymore.