### PR TITLE
Stop threshold change

### DIFF
--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -37,6 +37,8 @@ angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
 
 # Set reconstruction parameters
 stop_threshold = 0.05                       # Controls when the recon algorithm stops. stop_threshold = 100* (average value change) / (average voxel value)
+                                            # Note that the synthetic SL phantom tends to require a smaller value of stop_threshold
+                                            # However, the default threshold should work fine for most real data cases.
 sharpness = 0.0                             # Controls regularization: larger => sharper; smaller => smoother
 T = 0.1                                     # Controls edginess of reconstruction
 

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -36,6 +36,7 @@ num_views = 64                               # Number of projection views
 angles = np.linspace(0, 2 * np.pi, num_views, endpoint=False)
 
 # Set reconstruction parameters
+stop_threshold = 0.05                       # Controls when the recon algorithm stops. stop_threshold = 100* (average value change) / (average voxel value)
 sharpness = 0.0                             # Controls regularization: larger => sharper; smaller => smoother
 T = 0.1                                     # Controls edginess of reconstruction
 
@@ -76,7 +77,7 @@ print('Synthetic sinogram shape: (num_views, num_det_rows, num_det_channels) = '
 # Perform 3D MBIR reconstruction using qGGMRF prior
 ######################################################################################
 print('Performing 3D qGGMRF reconstruction ...\n')
-recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, T=T)
+recon = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification, sharpness=sharpness, T=T, stop_threshold=stop_threshold)
 (num_image_slices, num_image_rows, num_image_cols) = np.shape(recon)
 print('recon shape = ', np.shape(recon))
 

--- a/dev_scripts/reinstall_conda_environment.sh
+++ b/dev_scripts/reinstall_conda_environment.sh
@@ -7,7 +7,7 @@ NAME=mbircone
 
 ENV_STRING=$((conda env list) | grep $NAME)
 if [[ $ENV_STRING == *$NAME* ]]; then
-  echo conda deactivate
+    conda deactivate
 fi
 cd ..
 

--- a/mbircone/cone3D.py
+++ b/mbircone/cone3D.py
@@ -388,7 +388,7 @@ def denoise(img_noisy,
             sharpness=0.0, sigma_x=None, sigma_w=None,
             init_image=None,
             p=1.2, q=2.0, T=1.0, num_neighbors=6,
-            positivity=True, stop_threshold=0.02, max_iterations=100,
+            positivity=True, stop_threshold=0.2, max_iterations=100,
             verbose=1):
     """ Perform denoising using a proximal map with a qGGMRF objective function. This denoiser internally uses ICD to approximate the solution to the proximal map.
 
@@ -410,7 +410,7 @@ def denoise(img_noisy,
             Number of neighbors in the qGGMRF neighborhood. More neighbors results in a better
             regularization but a slower denoising.
         positivity (bool, optional): [Default=True] Determines if positivity constraint will be enforced.
-        stop_threshold (float, optional): [Default=0.02] Relative update stopping threshold, in percent, where relative update is given by (average value change) / (average voxel value).
+        stop_threshold (float, optional): [Default=0.2] Relative update stopping threshold, in percent, where relative update is given by (average value change) / (average voxel value).
         max_iterations (int, optional): [Default=100] Maximum number of iterations before stopping.
         verbose (int, optional): [Default=1] Possible values are {0,1,2}, where 0 is quiet, 1 prints minimal denoising progress information, and 2 prints the full information.
     Returns:
@@ -507,7 +507,7 @@ def recon(sino, angles, dist_source_detector, magnification,
           delta_det_channel=1.0, delta_det_row=1.0, delta_pixel_image=None,
           det_channel_offset=0.0, det_row_offset=0.0, rotation_offset=0.0, image_slice_offset=0.0,
           sigma_y=None, snr_db=40.0, sigma_x=None, sigma_p=None, p=1.2, q=2.0, T=1.0, num_neighbors=6,
-          sharpness=0.0, positivity=True, max_resolutions=None, stop_threshold=0.02, max_iterations=100,
+          sharpness=0.0, positivity=True, max_resolutions=None, stop_threshold=0.2, max_iterations=100,
           NHICD=False, num_threads=None, verbose=1, lib_path=__lib_path):
     """ Compute 3D cone beam MBIR reconstruction
 
@@ -578,7 +578,7 @@ def recon(sino, angles, dist_source_detector, magnification,
         max_resolutions (int, optional): [Default=None] Integer :math:`\geq 0` that specifies the maximum number of grid
             resolutions used to solve MBIR reconstruction problem.
             If None, automatically set by ``cone3D.auto_max_resolutions``.
-        stop_threshold (float, optional): [Default=0.02] Relative update stopping threshold, in percent, where relative
+        stop_threshold (float, optional): [Default=0.2] Relative update stopping threshold, in percent, where relative
             update is given by (average value change) / (average voxel value).
         max_iterations (int, optional): [Default=100] Maximum number of iterations before stopping.
 


### PR DESCRIPTION
This PR contains two very simple changes:
1. Change the default value of stop_threshold from 0.02 to 0.2.
    - In demo_3D_shepp_logan.py, set stop_threhold=0.05.
2. Fix the bug in reinstall_conda_environment.sh.

To test, first run clean_install_all.sh, then run demo_nsi_preprocess.py. The recon is x2 faster, and results in the same image quality as before.