### PR TITLE
Convergence criteria: normalize by absolute value of the pixels

### DIFF
--- a/mbircone/src/icd3d.c
+++ b/mbircone/src/icd3d.c
@@ -383,7 +383,7 @@ void updateIterationStats(struct ReconAux *reconAux, struct ICDInfo3DCone *icdIn
 {
     reconAux->TotalValueChange += fabs(icdInfo->Delta_xj);
     //reconAux->TotalVoxelValue += _MAX_(img->vox[icdInfo->j_x][icdInfo->j_y][icdInfo->j_z], icdInfo->old_xj);
-    reconAux->TotalVoxelValue += _MAX_(img->vox[index_3D(icdInfo->j_x,icdInfo->j_y,icdInfo->j_z,img->params.N_y,img->params.N_z)], icdInfo->old_xj);
+    reconAux->TotalVoxelValue += _MAX_(fabs(img->vox[index_3D(icdInfo->j_x,icdInfo->j_y,icdInfo->j_z,img->params.N_y,img->params.N_z)]), fabs(icdInfo->old_xj));
     reconAux->NumUpdatedVoxels++;
 }
 
@@ -723,7 +723,7 @@ void updateIterationStatsGroup(struct ReconAux *reconAux, struct ICDInfo3DCone *
 
         absDelta = fabs(icdInfo->Delta_xj);
         //totValue = _MAX_(img->vox[j_x][j_y][j_z], icdInfo->old_xj);
-        totValue = _MAX_(img->vox[index_3D(j_x,j_y,j_z,img->params.N_y,img->params.N_z)], icdInfo->old_xj);
+        totValue = _MAX_(fabs(img->vox[index_3D(j_x,j_y,j_z,img->params.N_y,img->params.N_z)]), fabs(icdInfo->old_xj));
 
         reconAux->TotalValueChange     += absDelta;
         reconAux->TotalVoxelValue     += totValue;


### PR DESCRIPTION
This PR makes a simple change to the convergence criteria (CC). The new CC is normalized by the average **absolute value** of the pixels.

Define:
$n$: iteration number.
$i$: voxel index.

Old CC:
$$CC(n)=\frac{\sum_i\mid x_i^{(n)} - x_i^{(n-1)} \mid}{\sum_i max \left\lbrace  x_i^{(n)}, x_i^{(n-1)} \right\rbrace  }$$


New CC:
$$CC(n)=\frac{\sum_i\mid x_i^{(n)} - x_i^{(n-1)} \mid}{\sum_i max \left\lbrace  \mid x_i^{(n)}\mid , \mid x_i^{(n-1)}\mid \right\rbrace  }$$

Tested `demo_3D_shepp_logan.py` and `demo_nsi_preprocess.py`. In both cases the image quality and number of iterations remain the same as before. This makes since because the images are non-negative. 