### PR TITLE
Fix requirements

### DIFF
--- a/mbircone/src/MBIRModularUtilities3D.c
+++ b/mbircone/src/MBIRModularUtilities3D.c
@@ -39,7 +39,7 @@ void backProjectlike3DCone( float ***x_out, float ***y_in, struct ImageParams *i
 
     long int j_u, j_x, j_y, i_beta, i_v, j_z, i_w;
     float B_ij, A_ij;
-    float ticToc;
+    double ticToc;
     float ***normalization, val, val2;
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow>=9.1
 dask~=2022.4.1
 dask-jobqueue~=0.7.3
 scikit-image
+docstring_inheritance


### PR DESCRIPTION
This PR contains two simple fixes:
1. Add docstring_inheritance to requirements.txt
2. Change data type of variable "ticToc" from float to double to suppress compiler warning.

Tested and worked fine. 