### PR TITLE
Interpolate defective sino entries

### DIFF
--- a/demo/demo_metal_artifact.py
+++ b/demo/demo_metal_artifact.py
@@ -102,6 +102,11 @@ sino, defective_pixel_list = \
 del obj_scan, blank_scan, dark_scan
 
 print("\n*******************************************************",
+      "\n********* Interpolate defective sino entries **********",
+      "\n*******************************************************")
+sino, defective_pixel_list = mbircone.preprocess.interpolate_defective_pixels(sino, defective_pixel_list)
+
+print("\n*******************************************************",
       "\n************** Correct background offset **************",
       "\n*******************************************************")
 background_offset = mbircone.preprocess.calc_background_offset(sino)

--- a/demo/demo_nsi_preprocess.py
+++ b/demo/demo_nsi_preprocess.py
@@ -84,6 +84,11 @@ sino, defective_pixel_list = \
 del obj_scan, blank_scan, dark_scan
 
 print("\n*******************************************************",
+      "\n********* Interpolate defective sino entries **********",
+      "\n*******************************************************")
+sino, defective_pixel_list = mbircone.preprocess.interpolate_defective_pixels(sino, defective_pixel_list)
+
+print("\n*******************************************************",
       "\n************** Correct background offset **************",
       "\n*******************************************************")
 background_offset = mbircone.preprocess.calc_background_offset(sino)

--- a/docs/source/preprocess.rst
+++ b/docs/source/preprocess.rst
@@ -1,7 +1,7 @@
 mbircone.preprocess
 -------------------
 .. automodule:: mbircone.preprocess
-   :members: 
+   :members: NSI_load_scans_and_params, transmission_CT_compute_sino, calc_background_offset, calc_weights, calc_weights_mar, interpolate_defective_pixels 
    :undoc-members:
    :show-inheritance:
 
@@ -14,3 +14,4 @@ mbircone.preprocess
       calc_background_offset
       calc_weights
       calc_weights_mar
+      interpolate_defective_pixels


### PR DESCRIPTION
This PR contains the preprocess module update that interpolates the defective sino entries.
Note that the rotation axis tilt is **NOT** included in this PR.

The test results are sent out separately via email.