### PR TITLE
HDF5 utils

### DIFF
--- a/demo/demo_hdf5_io.py
+++ b/demo/demo_hdf5_io.py
@@ -1,0 +1,84 @@
+import os
+import numpy as np
+import h5py
+import mbircone
+from demo_utils import plot_image, plot_gif
+
+"""
+This script demonstrates how to save image data in HDF5 format. 
+Demo functionality includes:
+ * Generating a 3D Shepp Logan phantom;
+ * Writing the image data as a HDF5 file using function `mbircone.utils.hdf5_write`;
+ * Reading the image data and metadata from the HDF5 file using function `mbircone.utils.hdf5_read`;
+ * Printing out the image metadata and displaying the image slices.
+"""
+print('This script demonstrates how to save image data in HDF5 format.\
+Demo functionality includes:\
+\n\t * Generating a 3D Shepp Logan phantom; \
+\n\t * Writing the image data as a HDF5 file using function `mbircone.utils.hdf5_write`; \
+\n\t * Reading the image data and metadata from the HDF5 file using function `mbircone.utils.hdf5_read`; \
+\n\t * Printing out the image metadata and displaying the image slices.\n')
+
+######### local path to save the HDF5 file and image slices
+save_path = f'output/HDF5_IO/'
+os.makedirs(save_path, exist_ok=True)
+# path to the HDF5 file
+hdf5_filename = os.path.join(save_path, "phantom.h5") 
+
+######### dimension of the phantom
+num_phantom_slices = 128
+num_phantom_rows = 128
+num_phantom_cols = 128
+
+######### Synthetic image metadata
+source = "3D shepp logan phantom" # source of the data
+alu_def = "5 mm" # Definition of 1 ALU
+delta_pixel_image = 1 # image pixel pitch = 1 ALU
+
+# Set display parameters for Shepp Logan phantom
+vmin = 1.0
+vmax = 1.2
+
+print('Genrating 3D Shepp Logan phantom ...\n')
+######################################################################################
+# Generate a 3D shepp logan phantom
+######################################################################################
+phantom = mbircone.phantom.gen_shepp_logan_3d(num_phantom_rows, num_phantom_cols, num_phantom_slices)
+print('Phantom shape = ', np.shape(phantom))
+
+######################################################################################
+# Save the phantom data as an HDF5 file
+######################################################################################
+print('Saving phantom data as an HDF5 file ...\n')
+mbircone.utils.hdf5_write(phantom, filename=hdf5_filename, 
+                           source=source, alu_def=alu_def, delta_pixel_image=delta_pixel_image)
+
+######################################################################################
+# Load the HDF5 file and print out the metadata information
+######################################################################################
+print('Loading the HDF5 file ...\n')
+phantom, metadata = mbircone.utils.hdf5_read(hdf5_filename)
+print("shape of phantom data = ", phantom.shape)
+print("Metadata of HDF5 file:",)
+for k in metadata.keys():
+    print(f"{k}: ", metadata[k])
+
+
+######################################################################################
+# Display phantom slices
+######################################################################################
+# Set display indexes for phantom and recon images
+display_slice_phantom = num_phantom_slices // 2
+display_x_phantom = num_phantom_rows // 2
+display_y_phantom = num_phantom_cols // 2
+
+plot_image(phantom[display_slice_phantom], title=f'phantom, axial slice {display_slice_phantom}',
+           filename=os.path.join(save_path, 'phantom_axial.png'), vmin=vmin, vmax=vmax)
+plot_image(phantom[:,display_x_phantom,:], title=f'phantom, coronal slice {display_x_phantom}',
+           filename=os.path.join(save_path, 'phantom_coronal.png'), vmin=vmin, vmax=vmax)
+plot_image(phantom[:,:,display_y_phantom], title=f'phantom, sagittal slice {display_y_phantom}',
+           filename=os.path.join(save_path, 'phantom_sagittal.png'), vmin=vmin, vmax=vmax)
+           
+print(f"Images saved to {save_path}.") 
+input("Press Enter")
+

--- a/mbircone/__init__.py
+++ b/mbircone/__init__.py
@@ -5,3 +5,4 @@ from .mace import mace3D, mace4D
 from .phantom import *
 from .multinode import *
 from .laminography import *
+from .utils import *

--- a/mbircone/_utils.py
+++ b/mbircone/_utils.py
@@ -7,6 +7,51 @@ import os
 import hashlib
 import random
 from PIL import Image
+import h5py
+
+def hdf5_save(image, filename="recon.h5", 
+              source="", alu_def="", delta_pixel_image=1.0, recon_unit="ALU^{-1}"):
+    """ Save a reconstruction image as an HDF5 file. The file structure is defined as follows:
+        
+        Dataset:
+            - **voxels** (*ndarray*): 3D image to be saved.
+        Attributes:
+            - **README** (*string*): long string defining the structure of the HDF5 file.
+            - **source** (*string*): source file of the reconstruction. Example: "reconstruction.nsihdr".
+            - **alu_def** (*string*): definition of arbitrary length units (ALU). Example: "5 mm".
+            - **delta_pixel_image** (*float*): Image pixel spacing in ALU.
+            - **recon_unit** (*string*): unit of the reconstruction data. Example: "mm^{-1}"`.
+    Args:
+        image (float, ndarray): 3D image to be saved.
+        filename (string, optional) [Default="recon.h5"] Path to save the HDF5 file.
+        source (string, optional) [Default=""] source file of the reconstruction. Example: "reconstruction.nsihdr".
+        alu_def (string, optional) [Default=""] definition of arbitrary length units (ALU). Example: "5 mm".
+        delta_pixel_image (float, optional) [Default=1.0]: Image pixel spacing in ALU.
+        recon_unit (string, optional): [Default="ALU^{-1}"] unit of the reconstruction data. Example: "mm^{-1}"
+    """
+    
+    with h5py.File(filename, "w") as f:
+        # voxel values
+        f.create_dataset("voxels", data=image)
+        # image shape
+        f.attrs["source"] = source
+        f.attrs["alu_def"] = alu_def
+        f.attrs["delta_pixel_image"] = delta_pixel_image
+        f.attrs["recon_unit"] = recon_unit
+        f.attrs["README"] = \
+            """
+            The structure of this file is defined as follows:
+                Dataset:
+                - voxels (ndarray): 3D image to be saved.
+                Attributes:
+                - README (string): long string defining the structure of the HDF5 file.
+                - source (string): source file of the reconstruction. Example: "reconstruction.nsihdr".
+                - alu_def (string): definition of arbitrary length units (ALU). Example: "5 mm".
+                - delta_pixel_image (float): Image pixel spacing in ALU.
+                - recon_unit (string): unit of the reconstruction data. Example: "mm^{-1}"`.
+            """
+    return
+
 
 def hash_params(angles, sinoparams, imgparams):
     hash_input = str(sinoparams) + str(imgparams) + str(np.around(angles, decimals=6))

--- a/mbircone/_utils.py
+++ b/mbircone/_utils.py
@@ -7,51 +7,6 @@ import os
 import hashlib
 import random
 from PIL import Image
-import h5py
-
-def hdf5_save(image, filename="recon.h5", 
-              source="", alu_def="", delta_pixel_image=1.0, recon_unit="ALU^{-1}"):
-    """ Save a reconstruction image as an HDF5 file. The file structure is defined as follows:
-        
-        Dataset:
-            - **voxels** (*ndarray*): 3D image to be saved.
-        Attributes:
-            - **README** (*string*): long string defining the structure of the HDF5 file.
-            - **source** (*string*): source file of the reconstruction. Example: "reconstruction.nsihdr".
-            - **alu_def** (*string*): definition of arbitrary length units (ALU). Example: "5 mm".
-            - **delta_pixel_image** (*float*): Image pixel spacing in ALU.
-            - **recon_unit** (*string*): unit of the reconstruction data. Example: "mm^{-1}"`.
-    Args:
-        image (float, ndarray): 3D image to be saved.
-        filename (string, optional) [Default="recon.h5"] Path to save the HDF5 file.
-        source (string, optional) [Default=""] source file of the reconstruction. Example: "reconstruction.nsihdr".
-        alu_def (string, optional) [Default=""] definition of arbitrary length units (ALU). Example: "5 mm".
-        delta_pixel_image (float, optional) [Default=1.0]: Image pixel spacing in ALU.
-        recon_unit (string, optional): [Default="ALU^{-1}"] unit of the reconstruction data. Example: "mm^{-1}"
-    """
-    
-    with h5py.File(filename, "w") as f:
-        # voxel values
-        f.create_dataset("voxels", data=image)
-        # image shape
-        f.attrs["source"] = source
-        f.attrs["alu_def"] = alu_def
-        f.attrs["delta_pixel_image"] = delta_pixel_image
-        f.attrs["recon_unit"] = recon_unit
-        f.attrs["README"] = \
-            """
-            The structure of this file is defined as follows:
-                Dataset:
-                - voxels (ndarray): 3D image to be saved.
-                Attributes:
-                - README (string): long string defining the structure of the HDF5 file.
-                - source (string): source file of the reconstruction. Example: "reconstruction.nsihdr".
-                - alu_def (string): definition of arbitrary length units (ALU). Example: "5 mm".
-                - delta_pixel_image (float): Image pixel spacing in ALU.
-                - recon_unit (string): unit of the reconstruction data. Example: "mm^{-1}"`.
-            """
-    return
-
 
 def hash_params(angles, sinoparams, imgparams):
     hash_input = str(sinoparams) + str(imgparams) + str(np.around(angles, decimals=6))

--- a/mbircone/utils.py
+++ b/mbircone/utils.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020-2022 by MBIRCONE Developers
+# All rights reserved. BSD 3-clause License.
+
+import numpy as np
+import h5py
+
+def hdf5_write(image, filename, 
+              source="", alu_def="", delta_pixel_image=1.0, recon_unit="ALU^{-1}"):
+    """ Save a reconstruction image as an HDF5 file. The file structure is defined as follows:
+        
+        Dataset:
+            - **voxels** (*ndarray*): 3D image to be saved.
+        Attributes:
+            - **README** (*string*): long string defining the structure of the HDF5 file.
+            - **source** (*string*): source file of the reconstruction. Example: "reconstruction.nsihdr".
+            - **alu_def** (*string*): definition of arbitrary length units (ALU). Example: "5 mm".
+            - **delta_pixel_image** (*float*): Image pixel spacing in ALU.
+            - **recon_unit** (*string*): unit of the reconstruction data. Example: "mm^{-1}"`.
+    Args:
+        image (float, ndarray): 3D image to be saved.
+        filename (string) Path to save the HDF5 file. Example: "<path_to_directory>/recon.h5"
+        source (string, optional) [Default=""] source file of the reconstruction. Example: "reconstruction.nsihdr".
+        alu_def (string, optional) [Default=""] definition of arbitrary length units (ALU). Example: "5 mm".
+        delta_pixel_image (float, optional) [Default=1.0]: Image pixel spacing in ALU.
+        recon_unit (string, optional): [Default="ALU^{-1}"] unit of the reconstruction data. Example: "mm^{-1}"
+    """
+    
+    with h5py.File(filename, "w") as f:
+        # voxel values
+        f.create_dataset("voxels", data=image)
+        # image shape
+        f.attrs["source"] = source
+        f.attrs["alu_def"] = alu_def
+        f.attrs["delta_pixel_image"] = delta_pixel_image
+        f.attrs["recon_unit"] = recon_unit
+        f.attrs["README"] = \
+            """
+            The structure of this file is defined as follows:
+                Dataset:
+                - voxels (ndarray): 3D image to be saved.
+                Attributes:
+                - README (string): long string defining the structure of the HDF5 file.
+                - source (string): source file of the reconstruction. Example: "reconstruction.nsihdr".
+                - alu_def (string): definition of arbitrary length units (ALU). Example: "5 mm".
+                - delta_pixel_image (float): Image pixel spacing in ALU.
+                - recon_unit (string): unit of the reconstruction data. Example: "mm^{-1}"`.
+            """
+    return
+
+
+def hdf5_read(filename):
+    """ Read the image data as well as its metadata from an HDF5 file. The HDF5 file is assumed to have the following structure:
+        Dataset:
+            - **voxels** (*ndarray*): 3D image data.
+        Attributes:
+            - **README** (*string*): long string defining the structure of the HDF5 file.
+            - **source** (*string*): source file of the reconstruction. Example: "reconstruction.nsihdr".
+            - **alu_def** (*string*): definition of arbitrary length units (ALU). Example: "5 mm".
+            - **delta_pixel_image** (*float*): Image pixel spacing in ALU.
+            - **recon_unit** (*string*): unit of the reconstruction data. Example: "mm^{-1}"`.
+
+    Args:
+        filename (string, optional) [Default="recon.h5"] Path to save the HDF5 file.
+    
+    Returns:
+        two-element tuple containing:
+
+        - **image** (*ndarray*): 3D image data.
+        - **metadata** (*dict*): A dictionary containing metadata of the image.
+    """
+    
+    f = h5py.File(filename, "r")
+    image = f["voxels"]  
+    metadata = {}
+    for k in f.attrs.keys():
+        metadata[k] = f.attrs[k]
+    return image, metadata


### PR DESCRIPTION
This PR is regarding the utility functions to save image data into an HDF5 file and read image data from an HDF5 file.
This PR contains two functions `mbircone.utils.hdf5_write()` and `mbircone.utils.hdf5_read()`, as well as a demo script `demo/demo_hdf5_io.py`.

- `hdf5_write()` saves a reconstruction image as an HDF5 file. The file structure is defined as follows:
                **Dataset:**
                - voxels (ndarray): 3D image to be saved.
                **Attributes:**
                - README (string): long string defining the structure of the HDF5 file.
                - source (string): source file of the reconstruction. Example: "reconstruction.nsihdr".
                - alu_def (string): definition of arbitrary length units (ALU). Example: "5 mm".
                - delta_pixel_image (float): Image pixel spacing in ALU.
                - recon_unit (string): unit of the reconstruction data. Example: "mm^{-1}"`.

- `hdf5_read()` read the image data as well as its metadata from an HDF5 file.

- The demo script demonstrates how to save image data as HDF5 file, and how to read image data and metadata from an HDF5 file. It includes:
  1. Generating a 3D Shepp Logan phantom;
  2. Writing the image data as a HDF5 file using function `mbircone.utils.hdf5_write`;
  3. Reading the image data and metadata from the HDF5 file using function `mbircone.utils.hdf5_read`;
  4.  Printing out the image metadata and displaying the image slices. Printing out the image metadata and displaying the image slices.. Printing out the image metadata and displaying the image slices.4. Printing out the image metadata and displaying the image slices.