### PR TITLE
NSI to MBIR parameter conversion

### DIFF
--- a/demo/demo_metal_artifact.py
+++ b/demo/demo_metal_artifact.py
@@ -31,35 +31,10 @@ print('This script is a demonstration of the metal artifact reduction (MAR) func
 # Set the parameters to get the data and do the recon 
 # ###########################################################################
 
-# ###################### Change the parameters below for your own use case.
-# ##### params for dataset downloading.
-# path to store output recon images
-save_path = './output/demo_metal_artifacts/'
-os.makedirs(save_path, exist_ok=True)
-
-# ##### Download and extract NSI dataset 
-# url to NSI dataset.
-dataset_url = 'https://engineering.purdue.edu/~bouman/data_repository/data/mar_demo_data.tgz'
-# destination path to download and extract the phantom and NN weight files.
-dataset_dir = './demo_data/' 
-# download dataset. The dataset path will be later used to define path to NSI files.
-dataset_path = demo_utils.download_and_extract(dataset_url, dataset_dir)
-
-# ##### NSI specific file paths
-# path to NSI config file. Change dataset path params for your own NSI dataset
-nsi_config_file_path = os.path.join(dataset_path, 'mar_demo_data/JB-033_ArtifactPhantom_VerticalMetal.nsipro')
-# path to "Geometry Report.rtf"
-geom_report_path = os.path.join(dataset_path, 'mar_demo_data/Geometry_Report_nsi_demo.rtf')
-# path to directory containing all object scans
-obj_scan_path = os.path.join(dataset_path, 'mar_demo_data/Radiographs-JB-033_ArtifactPhantom_VerticalMetal')
-# path to blank scan. Usually <dataset_path>/Corrections/gain0.tif
-blank_scan_path = os.path.join(dataset_path, 'mar_demo_data/Corrections/gain0.tif')
-# path to dark scan. Usually <dataset_path>/Corrections/offset.tif
-dark_scan_path = os.path.join(dataset_path, 'mar_demo_data/Corrections/offset.tif')
-# path to NSI file containing defective pixel information
-defective_pixel_path = os.path.join(dataset_path, 'mar_demo_data/Corrections/defective_pixels.defect')
-# downsample factor of scan images along detector rows and detector columns.
-downsample_factor = [6, 6]
+# ###################### User defined params. Change the parameters below for your own use case.
+save_path = './output/demo_metal_artifacts/' # path to store output recon images
+os.makedirs(save_path, exist_ok=True) # mkdir if directory does not exist
+downsample_factor = [6, 6] # downsample factor of scan images along detector rows and detector columns.
 # view subsample factor
 subsample_view_factor = 2
 
@@ -72,7 +47,33 @@ beta = 1.0
 # gamma controls the weight to sinogram entries in which the projection paths contain metal components.
 # A larger gamma promotes metal artifacts reduction around metal regions.
 gamma = 4.0
-# ######### End of parameters #########
+
+# ##### params for dataset downloading. User may change these parameters for their own datasets.
+# An example NSI dataset will be downloaded from `dataset_url`, and saved to `download_dir`.
+# url to NSI dataset.
+dataset_url = 'https://engineering.purdue.edu/~bouman/data_repository/data/mar_demo_data.tgz'
+# destination path to download and extract the NSI data and metadata.
+download_dir = './demo_data/'
+# download dataset. The download path will be later used to define path to dataset specific files.
+download_dir = demo_utils.download_and_extract(dataset_url, download_dir)
+# path to NSI dataset
+dataset_path = os.path.join(download_dir, "mar_demo_data") # change this for different NSI datasets.
+
+# ######### NSI specific file paths, These are derived from dataset_path.
+# User may change the variables below for a different NSI dataset.
+# path to NSI config file. Change dataset path params for your own NSI dataset
+nsi_config_file_path = os.path.join(dataset_path, 'JB-033_ArtifactPhantom_VerticalMetal.nsipro')
+# path to "Geometry Report.rtf"
+geom_report_path = os.path.join(dataset_path, 'Geometry_Report_nsi_demo.rtf')
+# path to directory containing all object scans
+obj_scan_path = os.path.join(dataset_path, 'Radiographs-JB-033_ArtifactPhantom_VerticalMetal')
+# path to blank scan. Usually <dataset_path>/Corrections/gain0.tif
+blank_scan_path = os.path.join(dataset_path, 'Corrections/gain0.tif')
+# path to dark scan. Usually <dataset_path>/Corrections/offset.tif
+dark_scan_path = os.path.join(dataset_path, 'Corrections/offset.tif')
+# path to NSI file containing defective pixel information
+defective_pixel_path = os.path.join(dataset_path, 'Corrections/defective_pixels.defect')
+# ###################### End of parameters
 
 t_start = time.time()
 # ###########################################################################

--- a/demo/demo_metal_artifact.py
+++ b/demo/demo_metal_artifact.py
@@ -82,12 +82,11 @@ print("\n***********************************************************************
       "\n** Load scan images, angles, geometry params, and defective pixel information **",
       "\n********************************************************************************")
 obj_scan, blank_scan, dark_scan, angles, geo_params, defective_pixel_list = \
-        mbircone.preprocess.NSI_load_scans_and_params(nsi_config_file_path, obj_scan_path, 
-                                                      blank_scan_path, dark_scan_path,
-                                                      geom_report_path=geom_report_path,
+        mbircone.preprocess.NSI_load_scans_and_params(nsi_config_file_path, geom_report_path,
+                                                      obj_scan_path, blank_scan_path, dark_scan_path,
+                                                      defective_pixel_path,
                                                       downsample_factor=downsample_factor,
-                                                      subsample_view_factor=subsample_view_factor,
-                                                      defective_pixel_path=defective_pixel_path)
+                                                      subsample_view_factor=subsample_view_factor)
 print("MBIR geometry paramemters:")
 pp.pprint(geo_params)
 print('obj_scan shape = ', obj_scan.shape)

--- a/demo/demo_nsi_preprocess.py
+++ b/demo/demo_nsi_preprocess.py
@@ -44,6 +44,8 @@ dataset_path = demo_utils.download_and_extract(dataset_url, dataset_dir)
 # ##### NSI specific file paths
 # path to NSI config file. Change dataset path params for your own NSI dataset
 nsi_config_file_path = os.path.join(dataset_path, 'demo_data_nsi/JB-033_ArtifactPhantom_Vertical_NoMetal.nsipro')
+# path to "Geometry Report.rtf"
+geom_report_path = os.path.join(dataset_path, 'demo_data_nsi/Geometry_Report_nsi_demo.rtf')
 # path to directory containing all object scans
 obj_scan_path = os.path.join(dataset_path, 'demo_data_nsi/Radiographs-JB-033_ArtifactPhantom_Vertical_NoMetal')
 # path to blank scan. Usually <dataset_path>/Corrections/gain0.tif
@@ -65,6 +67,7 @@ print("\n***********************************************************************
 obj_scan, blank_scan, dark_scan, angles, geo_params, defective_pixel_list = \
         mbircone.preprocess.NSI_load_scans_and_params(nsi_config_file_path, obj_scan_path, 
                                                       blank_scan_path, dark_scan_path,
+                                                      geom_report_path=geom_report_path,
                                                       downsample_factor=downsample_factor,
                                                       defective_pixel_path=defective_pixel_path)
 print("MBIR geometry paramemters:")
@@ -98,7 +101,7 @@ sino = sino - background_offset
 print("\n*******************************************************",
       "\n**** Rotate sino images w.r.t. rotation axis tilt *****",
       "\n*******************************************************")
-sino = mbircone.preprocess.correct_tilt(sino, tilt_angle=geo_params["rot_axis_tilt"])
+sino = mbircone.preprocess.correct_tilt(sino, tilt_angle=geo_params["rotation_axis_tilt"])
 
 print("\n*******************************************************",
       "\n************** Calculate sinogram weight **************",
@@ -121,9 +124,11 @@ delta_det_row = geo_params["delta_det_row"]
 delta_det_channel = geo_params["delta_det_channel"]
 det_channel_offset = geo_params["det_channel_offset"]
 det_row_offset = geo_params["det_row_offset"]
+rotation_offset = geo_params["rotation_offset"]
 # MBIR recon
 recon_mbir = mbircone.cone3D.recon(sino, angles, dist_source_detector, magnification,
                                    det_channel_offset=det_channel_offset, det_row_offset=det_row_offset,
+                                   rotation_offset=rotation_offset,
                                    delta_det_row=delta_det_row, delta_det_channel=delta_det_channel,
                                    weights=weights)
 np.save(os.path.join(save_path, "recon_mbir.npy"), recon_mbir)

--- a/demo/demo_nsi_preprocess.py
+++ b/demo/demo_nsi_preprocess.py
@@ -65,11 +65,10 @@ print("\n***********************************************************************
       "\n** Load scan images, angles, geometry params, and defective pixel information **",
       "\n********************************************************************************")
 obj_scan, blank_scan, dark_scan, angles, geo_params, defective_pixel_list = \
-        mbircone.preprocess.NSI_load_scans_and_params(nsi_config_file_path, obj_scan_path, 
-                                                      blank_scan_path, dark_scan_path,
-                                                      geom_report_path=geom_report_path,
-                                                      downsample_factor=downsample_factor,
-                                                      defective_pixel_path=defective_pixel_path)
+        mbircone.preprocess.NSI_load_scans_and_params(nsi_config_file_path, geom_report_path,
+                                                      obj_scan_path, blank_scan_path, dark_scan_path,
+                                                      defective_pixel_path,
+                                                      downsample_factor=downsample_factor)
 print("MBIR geometry paramemters:")
 pp.pprint(geo_params)
 print('obj_scan shape = ', obj_scan.shape)

--- a/demo/demo_nsi_preprocess.py
+++ b/demo/demo_nsi_preprocess.py
@@ -27,36 +27,37 @@ print('This script is a demonstration of the preprocessing module of NSI dataset
 # Set the parameters to get the data and do the recon 
 # ###########################################################################
 
-# ###################### Change the parameters below for your own use case.
-# ##### params for dataset downloading.
-# path to store output recon images
-save_path = './output/nsi_demo/'
-os.makedirs(save_path, exist_ok=True)
+# ###################### User defined params. Change the parameters below for your own use case.
+save_path = './output/nsi_demo/' # path to store output recon images
+os.makedirs(save_path, exist_ok=True) # mkdir if directory does not exist
+downsample_factor = [4, 4] # downsample factor of scan images along detector rows and detector columns.
 
-# ##### Download and extract NSI dataset 
+# ##### params for dataset downloading. User may change these parameters for their own datasets.
+# An example NSI dataset will be downloaded from `dataset_url`, and saved to `download_dir`.
 # url to NSI dataset.
 dataset_url = 'https://engineering.purdue.edu/~bouman/data_repository/data/demo_data_nsi.tgz'
-# destination path to download and extract the phantom and NN weight files.
-dataset_dir = './demo_data/'   
-# download dataset. The dataset path will be later used to define path to NSI files.
-dataset_path = demo_utils.download_and_extract(dataset_url, dataset_dir)
+# destination path to download and extract the NSI data and metadata.
+download_dir = './demo_data/'   
+# download dataset. The download path will be later used to define path to dataset specific files.
+download_dir = demo_utils.download_and_extract(dataset_url, download_dir)
+# path to NSI dataset
+dataset_path = os.path.join(download_dir, "demo_data_nsi") # change this for different NSI datasets.
 
-# ##### NSI specific file paths
+# ###################### NSI specific file paths, These are derived from dataset_path.
+# User may change the variables below for a different NSI dataset.
 # path to NSI config file. Change dataset path params for your own NSI dataset
-nsi_config_file_path = os.path.join(dataset_path, 'demo_data_nsi/JB-033_ArtifactPhantom_Vertical_NoMetal.nsipro')
+nsi_config_file_path = os.path.join(dataset_path, 'JB-033_ArtifactPhantom_Vertical_NoMetal.nsipro')
 # path to "Geometry Report.rtf"
-geom_report_path = os.path.join(dataset_path, 'demo_data_nsi/Geometry_Report_nsi_demo.rtf')
+geom_report_path = os.path.join(dataset_path, 'Geometry_Report_nsi_demo.rtf')
 # path to directory containing all object scans
-obj_scan_path = os.path.join(dataset_path, 'demo_data_nsi/Radiographs-JB-033_ArtifactPhantom_Vertical_NoMetal')
+obj_scan_path = os.path.join(dataset_path, 'Radiographs-JB-033_ArtifactPhantom_Vertical_NoMetal')
 # path to blank scan. Usually <dataset_path>/Corrections/gain0.tif
-blank_scan_path = os.path.join(dataset_path, 'demo_data_nsi/Corrections/gain0.tif')
+blank_scan_path = os.path.join(dataset_path, 'Corrections/gain0.tif')
 # path to dark scan. Usually <dataset_path>/Corrections/offset.tif
-dark_scan_path = os.path.join(dataset_path, 'demo_data_nsi/Corrections/offset.tif')
+dark_scan_path = os.path.join(dataset_path, 'Corrections/offset.tif')
 # path to NSI file containing defective pixel information
-defective_pixel_path = os.path.join(dataset_path, 'demo_data_nsi/Corrections/defective_pixels.defect')
-# downsample factor of scan images along detector rows and detector columns.
-downsample_factor = [4, 4]
-# ######### End of parameters #########
+defective_pixel_path = os.path.join(dataset_path, 'Corrections/defective_pixels.defect')
+# ###################### End of parameters
 
 # ###########################################################################
 # NSI preprocess: obtain sinogram, sino weights, angles, and geometry params

--- a/demo/demo_utils.py
+++ b/demo/demo_utils.py
@@ -135,7 +135,7 @@ def download_and_extract(download_url, save_dir):
         save_dir (string): Path to parent directory where downloaded file will be saved . 
     Return:
         string: path to downloaded file. This will be ``save_dir``+ downloaded_file_name 
-            In case whereno download is performed, the function will return path to the existing local file.
+            In case where no download is performed, the function will return path to the existing local file.
             In case where a tarball file is downloaded and extracted, the function will return the path to the parent directory where the file is extracted to, which is the save as ``save_dir``. 
     """
 

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,4 +1,4 @@
-mbircone.cone3D
+mbircone.utils
 ---------------
 .. automodule:: mbircone.utils
    :members: hdf5_write

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,0 +1,12 @@
+mbircone.cone3D
+---------------
+.. automodule:: mbircone.utils
+   :members: hdf5_write
+   :undoc-members:    
+   :show-inheritance:
+
+   .. rubric:: **Functions:**
+
+   .. autosummary::
+
+      hdf5_write

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -312,6 +312,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
         - obj_scan_path (string): Path to an NSI radiograph directory.
         - blank_scan_path (string): [Default=None] Path to a blank scan image, e.g. 'dataset_path/Corrections/gain0.tif'
         - dark_scan_path (string): [Default=None] Path to a dark scan image, e.g. 'dataset_path/Corrections/offset.tif'
+        - geom_report_path (string): [Default=None] Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
         - defective_pixel_path (string): [Default=None] Path to the file containing defective pixel information, e.g. 'dataset_path/Corrections/defective_pixels.defect'
 
     **Arguments specific to radiograph downsampling and cropping**:
@@ -493,7 +494,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     geo_params["det_channel_offset"] = det_channel_offset
     geo_params["det_row_offset"] = det_row_offset
     geo_params["rotation_offset"] = rotation_offset
-    geo_params["rotation_tilt_angle"] = tilt_angle # tilt angle of rotation axis
+    geo_params["rotation_axis_tilt"] = tilt_angle # tilt angle of rotation axis
     ############### END Convert NSI geometry parameters to MBIR parameters
     
     ############### Adjust geometry NSI_params according to crop_factor and downsample_factor

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -454,7 +454,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     r_a = NSI_params[12].split(' ')
     r_a = np.array([np.single(i) for i in r_a])
     # make sure rotation axis points down
-    if NSI_params[11] == "True":    # clockwise rotation: r_a from nsipro points up
+    if r_a[1] > 0:
         r_a = -r_a
     
     # Detector normal vector

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -7,7 +7,7 @@ import warnings
 import math
 from mbircone import cone3D
 import scipy
-from striprtf.striprtf import rtf_to_text
+import striprtf.striprtf as striprtf
 
 __lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
 
@@ -178,7 +178,7 @@ def _NSI_read_image_center_from_geom_report(geom_report_path):
     rtf_file = open(geom_report_path, 'r')
     rtf_raw = rtf_file.read()
     rtf_file.close()
-    rtf_converted = rtf_to_text(rtf_raw).split("\n")
+    rtf_converted = striprtf.rtf_to_text(rtf_raw).split("\n")
     for line in rtf_converted:
         if "Image center" in line:
             data = re.findall(r"(\d+\.*\d*, \d+\.*\d*)", line)

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -491,7 +491,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     geo_params['delta_det_row'] = geo_params['delta_det_row'] * downsample_factor[0]
     geo_params['delta_det_channel'] = geo_params['delta_det_channel'] * downsample_factor[1]
 
-    ############### Adjust detector size params w.r.t. downsampling arguments
+    ############### Adjust detector size params w.r.t. cropping arguments
     num_det_rows_shift0 = np.round(geo_params['num_det_rows'] * r0)
     num_det_rows_shift1 = np.round(geo_params['num_det_rows'] * (1 - r1))
     geo_params['num_det_rows'] = geo_params['num_det_rows'] - (num_det_rows_shift0 + num_det_rows_shift1)

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -181,7 +181,10 @@ def _crop_scans(obj_scan, blank_scan, dark_scan,
 def _NSI_read_detector_location_from_geom_report(geom_report_path):
     """ Give the path to "Geometry Report.rtf", returns the X and Y coordinates of the first row and first column of the detector.
         It is observed that the coordinates given in "Geometry Report.rtf" is more accurate than the coordinates given in the <reference> field in nsipro file.
-        
+        Specifically, this function parses the information of "Image center" from "Geometry Report.rtf".
+        Example: 
+            - content in "Geometry Report.rtf": Image center    (95.707, 123.072) [mm]  / (3.768, 4.845) [in]
+            - Returns: (95.707, 123.072) 
     Args:
         geom_report_path (string): Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
     Returns:
@@ -190,9 +193,12 @@ def _NSI_read_detector_location_from_geom_report(geom_report_path):
     rtf_file = open(geom_report_path, 'r')
     rtf_raw = rtf_file.read()
     rtf_file.close()
+    # convert rft file content to plain text.
     rtf_converted = striprtf.rtf_to_text(rtf_raw).split("\n")
     for line in rtf_converted:
         if "Image center" in line:
+            # read the two floating numbers immediately following the keyword "Image center". 
+            # This is the X and Y coordinates of (0,0) detector pixel in units of mm.
             data = re.findall(r"(\d+\.*\d*, \d+\.*\d*)", line)
             break
     data = data[0].split(",")

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -354,12 +354,12 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     NSI_params = _NSI_read_str_from_config(config_file_path, tag_section_list)
 
     # coordinate of source
-    v_s = NSI_params[0].split(' ')
-    v_s = [np.single(i) for i in v_s]
+    r_s = NSI_params[0].split(' ')
+    r_s = [np.single(i) for i in r_s]
     
     # coordinate of reference
-    v_r = NSI_params[1].split(' ')
-    v_r = [np.single(i) for i in v_r]
+    r_r = NSI_params[1].split(' ')
+    r_r = [np.single(i) for i in r_r]
  
     # detector pixel pitch
     pixel_pitch_det = NSI_params[2].split(' ')
@@ -409,25 +409,26 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
         angle_step = -angle_step
 
     # Rotation axis
-    v_a = NSI_params[12].split(' ')
-    v_a = [np.single(i) for i in v_a]
+    r_a = NSI_params[12].split(' ')
+    r_a = [np.single(i) for i in r_a]
    
     # Detector normal vector
-    v_n = NSI_params[13].split(' ')
-    v_n = [np.single(i) for i in v_n]
+    r_n = NSI_params[13].split(' ')
+    r_n = [np.single(i) for i in r_n]
    
     # Detector horizontal vector
-    v_h = NSI_params[14].split(' ')
-    v_h = [np.single(i) for i in v_h]
+    r_h = NSI_params[14].split(' ')
+    r_h = [np.single(i) for i in r_h]
 
-    print("####### NSI parameters:")
-    print("vector from origin to source = ", v_s, " [mm]")
-    print("vector from origin to reference = ", v_r, " [mm]")
-    print("Unit vector of rotation axis = ", v_a)
-    print("Unit vector of normal = ", v_n)
-    print("Unit vector of horizontal = ", v_h)
+    print("############ NSI parameters ############")
+    print("vector from origin to source = ", r_s, " [mm]")
+    print("vector from origin to reference = ", r_r, " [mm]")
+    print("Unit vector of rotation axis = ", r_a)
+    print("Unit vector of normal = ", r_n)
+    print("Unit vector of horizontal = ", r_h)
     print(f"Detector pixel pitch: (Delta_r, Delta_c) = ({Delta_r:.3f},{Delta_c:.3f}) [mm]")
     print(f"Detector size: (N_r, N_c) = ({N_r},{N_c})")
+    print("############ End NSI parameters ############")
    
 
     ############### Adjust geometry NSI_params according to crop_factor and downsample_factor

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -276,13 +276,14 @@ def calc_row_channel_params(r_a, r_n, r_h, r_s, r_r, Delta_c, Delta_r, N_c, N_r)
     # rotation offset
     delta_source = r_s - project_vector_to_vector(r_s, r_n)
     delta_rot = delta_source - project_vector_to_vector(delta_source, r_a)# rotation offset vector (perpendicular to rotation axis)
-    rotation_offset = np.dot(delta_rot, np.cross(r_a, r_n))
+    rotation_offset = np.dot(delta_rot, np.cross(r_n, r_a))
     return det_channel_offset, det_row_offset, rotation_offset
 
 ######## END Functions for NSI-MBIR parameter conversion
 
 def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, dark_scan_path=None,
                               defective_pixel_path=None,
+                              reference=None,
                               downsample_factor=[1, 1], crop_factor=[(0, 0), (1, 1)],
                               view_id_start=0, view_angle_start=0.,
                               view_id_end=None, subsample_view_factor=1):
@@ -384,7 +385,9 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     # coordinate of reference
     r_r = NSI_params[1].split(' ')
     r_r = np.array([np.single(i) for i in r_r])
- 
+    if reference is not None:
+        r_r[:2] = reference
+        print("Corrected reference coordinate = ", r_r)
     # detector pixel pitch
     pixel_pitch_det = NSI_params[2].split(' ')
     Delta_c = np.single(pixel_pitch_det[0])
@@ -472,6 +475,7 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     geo_params["det_channel_offset"] = det_channel_offset
     geo_params["det_row_offset"] = det_row_offset
     geo_params["rotation_offset"] = rotation_offset
+    geo_params["rotation_tilt_angle"] = tilt_angle # tilt angle of rotation axis
     ############### END Convert NSI geometry parameters to MBIR parameters
     
     ############### Adjust geometry NSI_params according to crop_factor and downsample_factor

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -227,6 +227,13 @@ def angle_between(v1, v2):
     return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0))
 
 
+def project_vector_to_vector(u1, u2):
+    """ Projects the vector u1 onto the vector u2.
+    """
+    u2 = unit_vector(u2)
+    u1_proj = np.dot(u1, u2)*u_2
+    return u1_proj
+
 def project_vector_to_plane(u, n):
     """ Projects the vector u onto the plane defined by its normal vector n.
     """

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -11,339 +11,7 @@ import striprtf.striprtf as striprtf
 
 __lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
 
-
-def _read_scan_img(img_path):
-    """Reads a single scan image from an image path. This function is a subroutine to the function `_read_scan_dir`.
-
-    Args:
-        img_path (string): Path object or file object pointing to an image. 
-            The image type must be compatible with `PIL.Image.open()`. See `https://pillow.readthedocs.io/en/stable/reference/Image.html` for more details.
-    Returns:
-        ndarray (float): 2D numpy array. A single scan image.
-    """
-
-    img = np.asarray(Image.open(img_path))
-
-    if np.issubdtype(img.dtype, np.integer):
-        # make float and normalize integer types
-        maxval = np.iinfo(img.dtype).max
-        img = img.astype(np.float32) / maxval
-
-    return img.astype(np.float32)
-
-
-def _read_scan_dir(scan_dir, view_ids=[]):
-    """Reads a stack of scan images from a directory. This function is a subroutine to `NSI_load_scans_and_params`.
-
-    Args:
-        scan_dir (string): Path to a ConeBeam Scan directory. 
-            Example: "<absolute_path_to_dataset>/Radiographs"
-        view_ids (list[int]): List of view indices to specify which scans to read.
-    Returns:
-        ndarray (float): 3D numpy array, (num_views, num_det_rows, num_det_channels). A stack of scan images.
-    """
-
-    if view_ids == []:
-        warnings.warn("view_ids should not be empty.")
-
-    img_path_list = sorted(glob(os.path.join(scan_dir, '*')))
-    img_path_list = [img_path_list[idx] for idx in view_ids]
-    img_list = [_read_scan_img(img_path) for img_path in img_path_list]
-
-    # return shape = num_views x num_det_rows x num_det_channels
-    return np.stack(img_list, axis=0)
-
-
-def _downsample_scans(obj_scan, blank_scan, dark_scan,
-                      downsample_factor,
-                      defective_pixel_list=None):
-    """Performs Down-sampling to the scan images in the detector plane.
-
-    Args:
-        obj_scan (float): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
-        blank_scan (float): A blank scan. 2D numpy array, (num_det_rows, num_det_channels).
-        dark_scan (float): A dark scan. 3D numpy array, (num_det_rows, num_det_channels).
-        downsample_factor ([int, int]): Default=[1,1]] Two numbers to define down-sample factor.
-    Returns:
-        Downsampled scans
-        - **obj_scan** (*ndarray, float*): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
-        - **blank_scan** (*ndarray, float*): A blank scan. 3D numpy array, (num_det_rows, num_det_channels).
-        - **dark_scan** (*ndarray, float*): A dark scan. 3D numpy array, (num_det_rows, num_det_channels).
-    """
-
-    assert len(downsample_factor) == 2, 'factor({}) needs to be of len 2'.format(downsample_factor)
-    assert (downsample_factor[0]>=1 and downsample_factor[1]>=1), 'factor({}) along each dimension should be greater or equal to 1'.format(downsample_factor)
-
-    good_pixel_mask = np.ones((blank_scan.shape[1], blank_scan.shape[2]), dtype=int)
-    if defective_pixel_list is not None:
-        for (r,c) in defective_pixel_list:
-            good_pixel_mask[r,c] = 0
-
-    # crop the scan if the size is not divisible by downsample_factor.
-    new_size1 = downsample_factor[0] * (obj_scan.shape[1] // downsample_factor[0])
-    new_size2 = downsample_factor[1] * (obj_scan.shape[2] // downsample_factor[1])
-
-    obj_scan = obj_scan[:, 0:new_size1, 0:new_size2]
-    blank_scan = blank_scan[:, 0:new_size1, 0:new_size2]
-    dark_scan = dark_scan[:, 0:new_size1, 0:new_size2]
-    good_pixel_mask = good_pixel_mask[0:new_size1, 0:new_size2]
-
-    ###### Compute block sum of the high res scan images. Defective pixels are excluded.
-    # filter out defective pixels
-    good_pixel_mask = good_pixel_mask.reshape(good_pixel_mask.shape[0] // downsample_factor[0], downsample_factor[0],
-                                              good_pixel_mask.shape[1] // downsample_factor[1], downsample_factor[1])
-    obj_scan = obj_scan.reshape(obj_scan.shape[0],
-                                obj_scan.shape[1] // downsample_factor[0], downsample_factor[0],
-                                obj_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
-
-    blank_scan = blank_scan.reshape(blank_scan.shape[0],
-                                    blank_scan.shape[1] // downsample_factor[0], downsample_factor[0],
-                                    blank_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
-    dark_scan = dark_scan.reshape(dark_scan.shape[0],
-                                  dark_scan.shape[1] // downsample_factor[0], downsample_factor[0],
-                                  dark_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
-
-    # compute block sum
-    obj_scan = obj_scan.sum((2,4))
-    blank_scan = blank_scan.sum((2, 4))
-    dark_scan = dark_scan.sum((2, 4))
-    # number of good pixels in each down-sampling block
-    good_pixel_count = good_pixel_mask.sum((1,3))
-
-    # new defective pixel list = {indices of pixels where the downsampling block contains all bad pixels}
-    defective_pixel_list = np.argwhere(good_pixel_count < 1)
-
-    # compute block averaging by dividing block sum with number of good pixels in the block
-    obj_scan = obj_scan / good_pixel_count
-    blank_scan = blank_scan / good_pixel_count
-    dark_scan = dark_scan / good_pixel_count
-
-    return obj_scan, blank_scan, dark_scan, defective_pixel_list
-
-
-def _crop_scans(obj_scan, blank_scan, dark_scan,
-                crop_region=[(0, 1), (0, 1)],
-                defective_pixel_list=None):
-    """Crop obj_scan, blank_scan, and dark_scan images by decimal factors, and update defective_pixel_list accordingly. 
-    Args:
-        obj_scan (float): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
-        blank_scan (float) : A blank scan. 3D numpy array, (1, num_det_rows, num_det_channels).
-        dark_scan (float): A dark scan. 3D numpy array, (1, num_det_rows, num_det_channels).
-        crop_region ([(float, float),(float, float)] or [float, float, float, float]):
-            [Default=[(0, 1), (0, 1)]] Two points to define the bounding box. Sequence of [(row0, row1), (col0, col1)] or
-            [row0, row1, col0, col1], where 0<=row0 <= row1<=1 and 0<=col0 <= col1<=1.
-        
-            The scan images will be cropped using the following algorithm:
-                obj_scan <- obj_scan[:,Nr_lo:Nr_hi, Nc_lo:Nc_hi], where 
-                    - Nr_lo = round(row0 * obj_scan.shape[1])
-                    - Nr_hi = round(row1 * obj_scan.shape[1])
-                    - Nc_lo = round(col0 * obj_scan.shape[2])
-                    - Nc_hi = round(col1 * obj_scan.shape[2])
-
-    Returns:
-        Cropped scans
-        - **obj_scan** (*ndarray, float*): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
-        - **blank_scan** (*ndarray, float*): A blank scan. 3D numpy array, (1, num_det_rows, num_det_channels).
-        - **dark_scan** (*ndarray, float*): A dark scan. 3D numpy array, (1, num_det_rows, num_det_channels).
-    """
-    if isinstance(crop_region[0], (list, tuple)):
-        (row0, row1), (col0, col1) = crop_region
-    else:
-        row0, row1, col0, col1 = crop_region
-
-    assert 0 <= row0 <= row1 <= 1 and 0 <= col0 <= col1 <= 1, 'crop_region should be sequence of [(row0, row1), (col0, col1)] ' \
-                                                      'or [row0, row1, col0, col1], where 1>=row1 >= row0>=0 and 1>=col1 >= col0>=0.'
-    assert math.isclose(col0, 1 - col1), 'horizontal crop limits must be symmetric'
-
-    Nr_lo = round(row0 * obj_scan.shape[1])
-    Nc_lo = round(col0 * obj_scan.shape[2])
-
-    Nr_hi = round(row1 * obj_scan.shape[1])
-    Nc_hi = round(col1 * obj_scan.shape[2])
-
-    obj_scan = obj_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
-    blank_scan = blank_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
-    dark_scan = dark_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
-
-    # adjust the defective pixel information: any down-sampling block containing a defective pixel is also defective
-    i = 0
-    while i < len(defective_pixel_list):
-        (r,c) = defective_pixel_list[i]
-        (r_new, c_new) = (r-Nr_lo, c-Nc_lo)
-        # delete the index tuple if it falls outside the cropped region
-        if (r_new<0 or r_new>=obj_scan.shape[1] or c_new<0 or c_new>=obj_scan.shape[2]):
-            del defective_pixel_list[i]
-        else:
-            i+=1
-    return obj_scan, blank_scan, dark_scan, defective_pixel_list
-
-
-def _NSI_read_detector_location_from_geom_report(geom_report_path):
-    """ Give the path to "Geometry Report.rtf", returns the X and Y coordinates of the first row and first column of the detector.
-        It is observed that the coordinates given in "Geometry Report.rtf" is more accurate than the coordinates given in the <reference> field in nsipro file.
-        Specifically, this function parses the information of "Image center" from "Geometry Report.rtf".
-        Example: 
-            - content in "Geometry Report.rtf": Image center    (95.707, 123.072) [mm]  / (3.768, 4.845) [in]
-            - Returns: (95.707, 123.072) 
-    Args:
-        geom_report_path (string): Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
-    Returns:
-        (x_r, y_r): A tuple containing the X and Y coordinates of center of the first detector row and column.    
-    """
-    rtf_file = open(geom_report_path, 'r')
-    rtf_raw = rtf_file.read()
-    rtf_file.close()
-    # convert rft file content to plain text.
-    rtf_converted = striprtf.rtf_to_text(rtf_raw).split("\n")
-    for line in rtf_converted:
-        if "Image center" in line:
-            # read the two floating numbers immediately following the keyword "Image center". 
-            # This is the X and Y coordinates of (0,0) detector pixel in units of mm.
-            data = re.findall(r"(\d+\.*\d*, \d+\.*\d*)", line)
-            break
-    data = data[0].split(",")
-    x_r = float(data[0])
-    y_r = float(data[1])
-    return x_r, y_r
-
-def _NSI_read_str_from_config(filepath, tags_sections):
-    """Returns strings about dataset information read from NSI configuration file.
-
-    Args:
-        filepath (string): Path to NSI configuration file. The filename extension is '.nsipro'.
-        tags_sections (list[string,string]): Given tags and sections to locate the information we want to read.
-    Returns:
-        list[string], a list of strings have needed dataset information for reconstruction.
-
-    """
-    tag_strs = ['<' + tag + '>' for tag, section in tags_sections]
-    section_starts = ['<' + section + '>' for tag, section in tags_sections]
-    section_ends = ['</' + section + '>' for tag, section in tags_sections]
-    NSI_params = []
-
-    try:
-        with open(filepath, 'r') as f:
-            lines = f.readlines()
-    except IOError:
-        print("Could not read file:", filepath)
-
-    for tag_str, section_start, section_end in zip(tag_strs, section_starts, section_ends):
-        section_start_inds = [ind for ind, match in enumerate(lines) if section_start in match]
-        section_end_inds = [ind for ind, match in enumerate(lines) if section_end in match]
-        section_start_ind = section_start_inds[0]
-        section_end_ind = section_end_inds[0]
-
-        for line_ind in range(section_start_ind + 1, section_end_ind):
-            line = lines[line_ind]
-            if tag_str in line:
-                tag_ind = line.find(tag_str, 1) + len(tag_str)
-                if tag_ind == -1:
-                    NSI_params.append("")
-                else:
-                    NSI_params.append(line[tag_ind:].strip('\n'))
-
-    return NSI_params
-
-######## Functions for NSI-MBIR parameter conversion
-def unit_vector(v):
-    """ Normalize v. Returns v/||v|| """
-    return v / np.linalg.norm(v)
-
-def project_vector_to_vector(u1, u2):
-    """ Projects the vector u1 onto the vector u2. Returns the vector <u1|u2>.
-    """
-    u2 = unit_vector(u2)
-    u1_proj = np.dot(u1, u2)*u2
-    return u1_proj
-
-def calc_tilt_angle(r_a, r_n, r_h, r_v):
-    """ Calculate the tilt angle between the rotation axis and the detector columns in unit of radians. User should call `preprocess.correct_tilt()` to rotate the sinogram images w.r.t. to the tilt angle.
-    
-    Args:
-        r_a: 3D real-valued unit vector in direction of rotation axis pointing down.
-        r_n: 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
-        r_h: 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
-        r_v: 3D real-valued unit vector in direction parallel to detector columns pointing down.
-    Returns:
-        float number specifying the angle between the rotation axis and the detector columns in units of radians.
-    """
-    # project the rotation axis onto the detector plane
-    r_a_p = unit_vector(r_a - project_vector_to_vector(r_a, r_n))
-    # calculate angle between the projected rotation axis and the horizontal detector vector
-    tilt_angle = -np.arctan(np.dot(r_a_p, r_h)/np.dot(r_a_p, r_v))
-    return tilt_angle
-
-def calc_source_detector_params(r_a, r_n, r_h, r_s, r_r):
-    """ Calculate the MBIRCONE geometry parameters: dist_source_detector, magnification, and rotation axis tilt angle. 
-    Args:
-        r_a (tuple): 3D real-valued unit vector in direction of rotation axis pointing down.
-        r_n (tuple): 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
-        r_h (tuple): 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
-        r_s (tuple): 3D real-valued vector from origin to the source location.
-        r_r (tuple): 3D real-valued vector from origin to the center of pixel on first row and colum of detector.
-    Returns:
-        3-element tuple containing:
-        - **dist_source_detector** (float): Distance between the X-ray source and the detector in units of mm. 
-        - **magnification** (float): Magnification of the cone-beam geometry defined as
-            (source to detector distance)/(source to center-of-rotation distance).
-        - **tilt_angle (float)**: Angle between the rotation axis and the detector columns in units of radians.
-    """
-    r_n = unit_vector(r_n)      # make sure r_n is normalized
-    r_v = np.cross(r_n, r_h)    # r_v = r_n x r_h
-
-    #### vector pointing from source to center of rotation along the source-detector line.
-    r_s_r = project_vector_to_vector(-r_s, r_n) # project -r_s to r_n 
-    
-    #### vector pointing from source to detector along the source-detector line.
-    r_s_d = project_vector_to_vector(r_r-r_s, r_n)
-    
-    dist_source_detector = np.linalg.norm(r_s_d) # ||r_s_d||
-    dist_source_rotation = np.linalg.norm(r_s_r) # ||r_s_r||
-    magnification = dist_source_detector/dist_source_rotation 
-    tilt_angle = calc_tilt_angle(r_a, r_n, r_h, r_v) # rotation axis tilt angle
-    return dist_source_detector, magnification, tilt_angle
-
-def calc_row_channel_params(r_a, r_n, r_h, r_s, r_r, Delta_c, Delta_r, N_c, N_r):
-    """ Calculate the MBIRCONE geometry parameters: det_channel_offset, det_row_offset, rotation_offset. 
-    Args:
-        r_a (tuple): 3D real-valued unit vector in direction of rotation axis pointing down.
-        r_n (tuple): 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
-        r_h (tuple): 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
-        r_s (tuple): 3D real-valued vector from origin to the source location.
-        r_r (tuple): 3D real-valued vector from origin to the center of pixel on first row and colum of detector.
-        Delta_c (float): spacing between detector columns in units of mm.
-        Delta_r (float): spacing between detector rows in units of mm.
-        N_c (int): Number of detector channels.
-        N_r (int): Number of detector rows.
-    Returns:
-        3-element tuple containing:
-        - **det_channel_offset** (float): Distance in mm from center of detector to the source-detector line along a row. 
-        - **det_row_offset** (float): Distance in mm from center of detector to the source-detector line along a column. 
-        - **rotation_offset** (float): Distance in mm from source-detector line to axis of rotation.
-    """
-    r_n = unit_vector(r_n) # make sure r_n is normalized
-    r_h = unit_vector(r_h) # make sure r_h is normalized
-    r_v = np.cross(r_n, r_h) # r_v = r_n x r_h
-    
-    # vector pointing from center of detector to the first row and column of detector along detector columns.
-    c_v = -(N_r-1)/2*Delta_r*r_v 
-    # vector pointing from center of detector to the first row and column of detector along detector rows.
-    c_h = -(N_c-1)/2*Delta_c*r_h
-    # vector pointing from source to first row and column of detector.
-    r_s_r = r_r - r_s 
-    # vector pointing from source-detector line to center of detector. 
-    r_delta = r_s_r - project_vector_to_vector(r_s_r, r_n) - c_v - c_h
-    # detector row and channel offsets
-    det_channel_offset = -np.dot(r_delta, r_h)
-    det_row_offset = -np.dot(r_delta, r_v)
-    # rotation offset
-    delta_source = r_s - project_vector_to_vector(r_s, r_n)
-    delta_rot = delta_source - project_vector_to_vector(delta_source, r_a)# rotation offset vector (perpendicular to rotation axis)
-    rotation_offset = np.dot(delta_rot, np.cross(r_n, r_a))
-    return det_channel_offset, det_row_offset, rotation_offset
-
-######## END Functions for NSI-MBIR parameter conversion
-
+######## API functions for MBIRCONE users
 def NSI_load_scans_and_params(config_file_path, geom_report_path, 
                               obj_scan_path, blank_scan_path, dark_scan_path,
                               defective_pixel_path,
@@ -423,7 +91,7 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
 
         - **defective_pixel_list** (list(tuple)): A list of tuples containing indices of invalid sinogram pixels, with the format (detector_row_idx, detector_channel_idx).
     """
-    ############### NSI param tags in nsipro file
+    ### NSI param tags in nsipro file
     tag_section_list = [['source', 'Result'],                           # vector from origin to source
                         ['reference', 'Result'],                        # vector from origin to first row and column of the detector
                         ['pitch', 'Object Radiograph'],                 # detector pixel pitch
@@ -528,10 +196,10 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
     print(f"Detector pixel pitch: (Delta_r, Delta_c) = ({Delta_r:.3f},{Delta_c:.3f}) [mm]")
     print(f"Detector size: (N_r, N_c) = ({N_r},{N_c})")
     print("############ End NSI geometry parameters ############")
-    ############### END load NSI parameters from an nsipro file
+    ### END load NSI parameters from an nsipro file
     
     
-    ############### Convert NSI geometry parameters to MBIR parameters
+    ### Convert NSI geometry parameters to MBIR parameters
     dist_source_detector, magnification, tilt_angle = calc_source_detector_params(r_a, r_n, r_h, r_s, r_r)
     
     det_channel_offset, det_row_offset, rotation_offset = calc_row_channel_params(r_a, r_n, r_h, r_s, r_r, Delta_c, Delta_r, N_c, N_r)
@@ -548,22 +216,22 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
     geo_params["det_row_offset"] = det_row_offset
     geo_params["rotation_offset"] = rotation_offset
     geo_params["rotation_axis_tilt"] = tilt_angle # tilt angle of rotation axis
-    ############### END Convert NSI geometry parameters to MBIR parameters
+    ### END Convert NSI geometry parameters to MBIR parameters
     
-    ############### Adjust geometry NSI_params according to crop_region and downsample_factor
+    ### Adjust geometry NSI_params according to crop_region and downsample_factor
     if isinstance(crop_region[0], (list, tuple)):
         (row0, row1), (col0, col1) = crop_region
     else:
         row0, row1, col0, col1 = crop_region
 
-    ############### Adjust detector size and pixel pitch params w.r.t. downsampling arguments
+    ### Adjust detector size and pixel pitch params w.r.t. downsampling arguments
     geo_params['num_det_rows'] = (geo_params['num_det_rows'] // downsample_factor[0])
     geo_params['num_det_channels'] = (geo_params['num_det_channels'] // downsample_factor[1])
 
     geo_params['delta_det_row'] = geo_params['delta_det_row'] * downsample_factor[0]
     geo_params['delta_det_channel'] = geo_params['delta_det_channel'] * downsample_factor[1]
 
-    ############### Adjust detector size params w.r.t. cropping arguments
+    ### Adjust detector size params w.r.t. cropping arguments
     num_det_rows_shift0 = np.round(geo_params['num_det_rows'] * row0)
     num_det_rows_shift1 = np.round(geo_params['num_det_rows'] * (1 - row1))
     geo_params['num_det_rows'] = geo_params['num_det_rows'] - (num_det_rows_shift0 + num_det_rows_shift1)
@@ -572,7 +240,7 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
     num_det_channels_shift1 = np.round(geo_params['num_det_channels'] * (1 - col1))
     geo_params['num_det_channels'] = geo_params['num_det_channels'] - (num_det_channels_shift0 + num_det_channels_shift1)
 
-    ############### read blank scans and dark scans
+    ### read blank scans and dark scans
     blank_scan = np.expand_dims(_read_scan_img(blank_scan_path), axis=0)
     if dark_scan_path is not None:
         dark_scan = np.expand_dims(_read_scan_img(dark_scan_path), axis=0)
@@ -584,7 +252,7 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
     view_ids = list(range(view_id_start, view_id_end, subsample_view_factor))
     obj_scan = _read_scan_dir(obj_scan_path, view_ids)
 
-    ############### Load defective pixel information
+    ### Load defective pixel information
     if defective_pixel_path is not None:
         tag_section_list = [['Defect', 'Defective Pixels']]
         defective_loc = _NSI_read_str_from_config(defective_pixel_path, tag_section_list)
@@ -594,7 +262,7 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
         defective_pixel_list = None
 
 
-    ############### flip the scans according to flipH and flipV information from nsipro file
+    ### flip the scans according to flipH and flipV information from nsipro file
     if flipV:
         print("Flip scans vertically!")
         obj_scan = np.flip(obj_scan, axis=1)
@@ -616,7 +284,7 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
                 (r,c) = defective_pixel_list[i]
                 defective_pixel_list[i] = (r, blank_scan.shape[2]-c-1)
 
-    ############### rotate the scans according to scan_rotate param
+    ### rotate the scans according to scan_rotate param
     rot_count = scan_rotate // 90
     for n in range(rot_count):
         obj_scan = np.rot90(obj_scan, 1, axes=(2,1))
@@ -628,18 +296,18 @@ def NSI_load_scans_and_params(config_file_path, geom_report_path,
                 (r,c) = defective_pixel_list[i]
                 defective_pixel_list[i] = (c, blank_scan.shape[2]-r-1)
 
-    ############### crop the scans based on input params
+    ### crop the scans based on input params
     obj_scan, blank_scan, dark_scan, defective_pixel_list = _crop_scans(obj_scan, blank_scan, dark_scan,
                                                                         crop_region=crop_region,
                                                                         defective_pixel_list=defective_pixel_list)
 
-    ############### downsample the scans with block-averaging
+    ### downsample the scans with block-averaging
     if downsample_factor[0]*downsample_factor[1] > 1:
         obj_scan, blank_scan, dark_scan, defective_pixel_list = _downsample_scans(obj_scan, blank_scan, dark_scan,
                                                                                   downsample_factor=downsample_factor,
                                                                                   defective_pixel_list=defective_pixel_list)
 
-    ############### compute projection angles based on angle_step and rotation direction
+    ### compute projection angles based on angle_step and rotation direction
     view_angle_start_deg = np.rad2deg(view_angle_start)
     angle_step *= subsample_view_factor
     angles = np.deg2rad(np.array([(view_angle_start_deg+n*angle_step) % 360.0 for n in range(len(view_ids))]))
@@ -941,3 +609,340 @@ def calc_weights_mar(sino, angles, dist_source_detector, magnification,
                 raise Exception("calc_weights_mar: index information in defective_pixel_list cannot be parsed.")
 
     return weights
+######## END API functions for MBIRCONE users
+
+######## subroutines for loading scan images
+def _read_scan_img(img_path):
+    """Reads a single scan image from an image path. This function is a subroutine to the function `_read_scan_dir`.
+
+    Args:
+        img_path (string): Path object or file object pointing to an image. 
+            The image type must be compatible with `PIL.Image.open()`. See `https://pillow.readthedocs.io/en/stable/reference/Image.html` for more details.
+    Returns:
+        ndarray (float): 2D numpy array. A single scan image.
+    """
+
+    img = np.asarray(Image.open(img_path))
+
+    if np.issubdtype(img.dtype, np.integer):
+        # make float and normalize integer types
+        maxval = np.iinfo(img.dtype).max
+        img = img.astype(np.float32) / maxval
+
+    return img.astype(np.float32)
+
+
+def _read_scan_dir(scan_dir, view_ids=[]):
+    """Reads a stack of scan images from a directory. This function is a subroutine to `NSI_load_scans_and_params`.
+
+    Args:
+        scan_dir (string): Path to a ConeBeam Scan directory. 
+            Example: "<absolute_path_to_dataset>/Radiographs"
+        view_ids (list[int]): List of view indices to specify which scans to read.
+    Returns:
+        ndarray (float): 3D numpy array, (num_views, num_det_rows, num_det_channels). A stack of scan images.
+    """
+
+    if view_ids == []:
+        warnings.warn("view_ids should not be empty.")
+
+    img_path_list = sorted(glob(os.path.join(scan_dir, '*')))
+    img_path_list = [img_path_list[idx] for idx in view_ids]
+    img_list = [_read_scan_img(img_path) for img_path in img_path_list]
+
+    # return shape = num_views x num_det_rows x num_det_channels
+    return np.stack(img_list, axis=0)
+######## END subroutines for loading scan images
+
+######## subroutines for image cropping and down-sampling
+def _downsample_scans(obj_scan, blank_scan, dark_scan,
+                      downsample_factor,
+                      defective_pixel_list=None):
+    """Performs Down-sampling to the scan images in the detector plane.
+
+    Args:
+        obj_scan (float): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
+        blank_scan (float): A blank scan. 2D numpy array, (num_det_rows, num_det_channels).
+        dark_scan (float): A dark scan. 3D numpy array, (num_det_rows, num_det_channels).
+        downsample_factor ([int, int]): Default=[1,1]] Two numbers to define down-sample factor.
+    Returns:
+        Downsampled scans
+        - **obj_scan** (*ndarray, float*): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
+        - **blank_scan** (*ndarray, float*): A blank scan. 3D numpy array, (num_det_rows, num_det_channels).
+        - **dark_scan** (*ndarray, float*): A dark scan. 3D numpy array, (num_det_rows, num_det_channels).
+    """
+
+    assert len(downsample_factor) == 2, 'factor({}) needs to be of len 2'.format(downsample_factor)
+    assert (downsample_factor[0]>=1 and downsample_factor[1]>=1), 'factor({}) along each dimension should be greater or equal to 1'.format(downsample_factor)
+
+    good_pixel_mask = np.ones((blank_scan.shape[1], blank_scan.shape[2]), dtype=int)
+    if defective_pixel_list is not None:
+        for (r,c) in defective_pixel_list:
+            good_pixel_mask[r,c] = 0
+
+    # crop the scan if the size is not divisible by downsample_factor.
+    new_size1 = downsample_factor[0] * (obj_scan.shape[1] // downsample_factor[0])
+    new_size2 = downsample_factor[1] * (obj_scan.shape[2] // downsample_factor[1])
+
+    obj_scan = obj_scan[:, 0:new_size1, 0:new_size2]
+    blank_scan = blank_scan[:, 0:new_size1, 0:new_size2]
+    dark_scan = dark_scan[:, 0:new_size1, 0:new_size2]
+    good_pixel_mask = good_pixel_mask[0:new_size1, 0:new_size2]
+
+    ### Compute block sum of the high res scan images. Defective pixels are excluded.
+    # filter out defective pixels
+    good_pixel_mask = good_pixel_mask.reshape(good_pixel_mask.shape[0] // downsample_factor[0], downsample_factor[0],
+                                              good_pixel_mask.shape[1] // downsample_factor[1], downsample_factor[1])
+    obj_scan = obj_scan.reshape(obj_scan.shape[0],
+                                obj_scan.shape[1] // downsample_factor[0], downsample_factor[0],
+                                obj_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
+
+    blank_scan = blank_scan.reshape(blank_scan.shape[0],
+                                    blank_scan.shape[1] // downsample_factor[0], downsample_factor[0],
+                                    blank_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
+    dark_scan = dark_scan.reshape(dark_scan.shape[0],
+                                  dark_scan.shape[1] // downsample_factor[0], downsample_factor[0],
+                                  dark_scan.shape[2] // downsample_factor[1], downsample_factor[1]) * good_pixel_mask
+
+    # compute block sum
+    obj_scan = obj_scan.sum((2,4))
+    blank_scan = blank_scan.sum((2, 4))
+    dark_scan = dark_scan.sum((2, 4))
+    # number of good pixels in each down-sampling block
+    good_pixel_count = good_pixel_mask.sum((1,3))
+
+    # new defective pixel list = {indices of pixels where the downsampling block contains all bad pixels}
+    defective_pixel_list = np.argwhere(good_pixel_count < 1)
+
+    # compute block averaging by dividing block sum with number of good pixels in the block
+    obj_scan = obj_scan / good_pixel_count
+    blank_scan = blank_scan / good_pixel_count
+    dark_scan = dark_scan / good_pixel_count
+
+    return obj_scan, blank_scan, dark_scan, defective_pixel_list
+
+
+def _crop_scans(obj_scan, blank_scan, dark_scan,
+                crop_region=[(0, 1), (0, 1)],
+                defective_pixel_list=None):
+    """Crop obj_scan, blank_scan, and dark_scan images by decimal factors, and update defective_pixel_list accordingly. 
+    Args:
+        obj_scan (float): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
+        blank_scan (float) : A blank scan. 3D numpy array, (1, num_det_rows, num_det_channels).
+        dark_scan (float): A dark scan. 3D numpy array, (1, num_det_rows, num_det_channels).
+        crop_region ([(float, float),(float, float)] or [float, float, float, float]):
+            [Default=[(0, 1), (0, 1)]] Two points to define the bounding box. Sequence of [(row0, row1), (col0, col1)] or
+            [row0, row1, col0, col1], where 0<=row0 <= row1<=1 and 0<=col0 <= col1<=1.
+        
+            The scan images will be cropped using the following algorithm:
+                obj_scan <- obj_scan[:,Nr_lo:Nr_hi, Nc_lo:Nc_hi], where 
+                    - Nr_lo = round(row0 * obj_scan.shape[1])
+                    - Nr_hi = round(row1 * obj_scan.shape[1])
+                    - Nc_lo = round(col0 * obj_scan.shape[2])
+                    - Nc_hi = round(col1 * obj_scan.shape[2])
+
+    Returns:
+        Cropped scans
+        - **obj_scan** (*ndarray, float*): A stack of sinograms. 3D numpy array, (num_views, num_det_rows, num_det_channels).
+        - **blank_scan** (*ndarray, float*): A blank scan. 3D numpy array, (1, num_det_rows, num_det_channels).
+        - **dark_scan** (*ndarray, float*): A dark scan. 3D numpy array, (1, num_det_rows, num_det_channels).
+    """
+    if isinstance(crop_region[0], (list, tuple)):
+        (row0, row1), (col0, col1) = crop_region
+    else:
+        row0, row1, col0, col1 = crop_region
+
+    assert 0 <= row0 <= row1 <= 1 and 0 <= col0 <= col1 <= 1, 'crop_region should be sequence of [(row0, row1), (col0, col1)] ' \
+                                                      'or [row0, row1, col0, col1], where 1>=row1 >= row0>=0 and 1>=col1 >= col0>=0.'
+    assert math.isclose(col0, 1 - col1), 'horizontal crop limits must be symmetric'
+
+    Nr_lo = round(row0 * obj_scan.shape[1])
+    Nc_lo = round(col0 * obj_scan.shape[2])
+
+    Nr_hi = round(row1 * obj_scan.shape[1])
+    Nc_hi = round(col1 * obj_scan.shape[2])
+
+    obj_scan = obj_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
+    blank_scan = blank_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
+    dark_scan = dark_scan[:, Nr_lo:Nr_hi, Nc_lo:Nc_hi]
+
+    # adjust the defective pixel information: any down-sampling block containing a defective pixel is also defective
+    i = 0
+    while i < len(defective_pixel_list):
+        (r,c) = defective_pixel_list[i]
+        (r_new, c_new) = (r-Nr_lo, c-Nc_lo)
+        # delete the index tuple if it falls outside the cropped region
+        if (r_new<0 or r_new>=obj_scan.shape[1] or c_new<0 or c_new>=obj_scan.shape[2]):
+            del defective_pixel_list[i]
+        else:
+            i+=1
+    return obj_scan, blank_scan, dark_scan, defective_pixel_list
+######## END subroutines for image cropping and down-sampling
+
+######## subroutines for parsing NSI metadata
+def _NSI_read_detector_location_from_geom_report(geom_report_path):
+    """ Give the path to "Geometry Report.rtf", returns the X and Y coordinates of the first row and first column of the detector.
+        It is observed that the coordinates given in "Geometry Report.rtf" is more accurate than the coordinates given in the <reference> field in nsipro file.
+        Specifically, this function parses the information of "Image center" from "Geometry Report.rtf".
+        Example: 
+            - content in "Geometry Report.rtf": Image center    (95.707, 123.072) [mm]  / (3.768, 4.845) [in]
+            - Returns: (95.707, 123.072) 
+    Args:
+        geom_report_path (string): Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
+    Returns:
+        (x_r, y_r): A tuple containing the X and Y coordinates of center of the first detector row and column.    
+    """
+    rtf_file = open(geom_report_path, 'r')
+    rtf_raw = rtf_file.read()
+    rtf_file.close()
+    # convert rft file content to plain text.
+    rtf_converted = striprtf.rtf_to_text(rtf_raw).split("\n")
+    for line in rtf_converted:
+        if "Image center" in line:
+            # read the two floating numbers immediately following the keyword "Image center". 
+            # This is the X and Y coordinates of (0,0) detector pixel in units of mm.
+            data = re.findall(r"(\d+\.*\d*, \d+\.*\d*)", line)
+            break
+    data = data[0].split(",")
+    x_r = float(data[0])
+    y_r = float(data[1])
+    return x_r, y_r
+
+def _NSI_read_str_from_config(filepath, tags_sections):
+    """Returns strings about dataset information read from NSI configuration file.
+
+    Args:
+        filepath (string): Path to NSI configuration file. The filename extension is '.nsipro'.
+        tags_sections (list[string,string]): Given tags and sections to locate the information we want to read.
+    Returns:
+        list[string], a list of strings have needed dataset information for reconstruction.
+
+    """
+    tag_strs = ['<' + tag + '>' for tag, section in tags_sections]
+    section_starts = ['<' + section + '>' for tag, section in tags_sections]
+    section_ends = ['</' + section + '>' for tag, section in tags_sections]
+    NSI_params = []
+
+    try:
+        with open(filepath, 'r') as f:
+            lines = f.readlines()
+    except IOError:
+        print("Could not read file:", filepath)
+
+    for tag_str, section_start, section_end in zip(tag_strs, section_starts, section_ends):
+        section_start_inds = [ind for ind, match in enumerate(lines) if section_start in match]
+        section_end_inds = [ind for ind, match in enumerate(lines) if section_end in match]
+        section_start_ind = section_start_inds[0]
+        section_end_ind = section_end_inds[0]
+
+        for line_ind in range(section_start_ind + 1, section_end_ind):
+            line = lines[line_ind]
+            if tag_str in line:
+                tag_ind = line.find(tag_str, 1) + len(tag_str)
+                if tag_ind == -1:
+                    NSI_params.append("")
+                else:
+                    NSI_params.append(line[tag_ind:].strip('\n'))
+
+    return NSI_params
+######## END subroutines for parsing NSI metadata
+
+######## subroutines for NSI-MBIR parameter conversion
+def unit_vector(v):
+    """ Normalize v. Returns v/||v|| """
+    return v / np.linalg.norm(v)
+
+def project_vector_to_vector(u1, u2):
+    """ Projects the vector u1 onto the vector u2. Returns the vector <u1|u2>.
+    """
+    u2 = unit_vector(u2)
+    u1_proj = np.dot(u1, u2)*u2
+    return u1_proj
+
+def calc_tilt_angle(r_a, r_n, r_h, r_v):
+    """ Calculate the tilt angle between the rotation axis and the detector columns in unit of radians. User should call `preprocess.correct_tilt()` to rotate the sinogram images w.r.t. to the tilt angle.
+    
+    Args:
+        r_a: 3D real-valued unit vector in direction of rotation axis pointing down.
+        r_n: 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
+        r_h: 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
+        r_v: 3D real-valued unit vector in direction parallel to detector columns pointing down.
+    Returns:
+        float number specifying the angle between the rotation axis and the detector columns in units of radians.
+    """
+    # project the rotation axis onto the detector plane
+    r_a_p = unit_vector(r_a - project_vector_to_vector(r_a, r_n))
+    # calculate angle between the projected rotation axis and the horizontal detector vector
+    tilt_angle = -np.arctan(np.dot(r_a_p, r_h)/np.dot(r_a_p, r_v))
+    return tilt_angle
+
+def calc_source_detector_params(r_a, r_n, r_h, r_s, r_r):
+    """ Calculate the MBIRCONE geometry parameters: dist_source_detector, magnification, and rotation axis tilt angle. 
+    Args:
+        r_a (tuple): 3D real-valued unit vector in direction of rotation axis pointing down.
+        r_n (tuple): 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
+        r_h (tuple): 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
+        r_s (tuple): 3D real-valued vector from origin to the source location.
+        r_r (tuple): 3D real-valued vector from origin to the center of pixel on first row and colum of detector.
+    Returns:
+        3-element tuple containing:
+        - **dist_source_detector** (float): Distance between the X-ray source and the detector in units of mm. 
+        - **magnification** (float): Magnification of the cone-beam geometry defined as
+            (source to detector distance)/(source to center-of-rotation distance).
+        - **tilt_angle (float)**: Angle between the rotation axis and the detector columns in units of radians.
+    """
+    r_n = unit_vector(r_n)      # make sure r_n is normalized
+    r_v = np.cross(r_n, r_h)    # r_v = r_n x r_h
+
+    #### vector pointing from source to center of rotation along the source-detector line.
+    r_s_r = project_vector_to_vector(-r_s, r_n) # project -r_s to r_n 
+    
+    #### vector pointing from source to detector along the source-detector line.
+    r_s_d = project_vector_to_vector(r_r-r_s, r_n)
+    
+    dist_source_detector = np.linalg.norm(r_s_d) # ||r_s_d||
+    dist_source_rotation = np.linalg.norm(r_s_r) # ||r_s_r||
+    magnification = dist_source_detector/dist_source_rotation 
+    tilt_angle = calc_tilt_angle(r_a, r_n, r_h, r_v) # rotation axis tilt angle
+    return dist_source_detector, magnification, tilt_angle
+
+def calc_row_channel_params(r_a, r_n, r_h, r_s, r_r, Delta_c, Delta_r, N_c, N_r):
+    """ Calculate the MBIRCONE geometry parameters: det_channel_offset, det_row_offset, rotation_offset. 
+    Args:
+        r_a (tuple): 3D real-valued unit vector in direction of rotation axis pointing down.
+        r_n (tuple): 3D real-valued unit vector perpendicular to the detector plan pointing from source to detector.
+        r_h (tuple): 3D real-valued unit vector in direction parallel to detector rows pointing from left to right.
+        r_s (tuple): 3D real-valued vector from origin to the source location.
+        r_r (tuple): 3D real-valued vector from origin to the center of pixel on first row and colum of detector.
+        Delta_c (float): spacing between detector columns in units of mm.
+        Delta_r (float): spacing between detector rows in units of mm.
+        N_c (int): Number of detector channels.
+        N_r (int): Number of detector rows.
+    Returns:
+        3-element tuple containing:
+        - **det_channel_offset** (float): Distance in mm from center of detector to the source-detector line along a row. 
+        - **det_row_offset** (float): Distance in mm from center of detector to the source-detector line along a column. 
+        - **rotation_offset** (float): Distance in mm from source-detector line to axis of rotation.
+    """
+    r_n = unit_vector(r_n) # make sure r_n is normalized
+    r_h = unit_vector(r_h) # make sure r_h is normalized
+    r_v = np.cross(r_n, r_h) # r_v = r_n x r_h
+    
+    # vector pointing from center of detector to the first row and column of detector along detector columns.
+    c_v = -(N_r-1)/2*Delta_r*r_v 
+    # vector pointing from center of detector to the first row and column of detector along detector rows.
+    c_h = -(N_c-1)/2*Delta_c*r_h
+    # vector pointing from source to first row and column of detector.
+    r_s_r = r_r - r_s 
+    # vector pointing from source-detector line to center of detector. 
+    r_delta = r_s_r - project_vector_to_vector(r_s_r, r_n) - c_v - c_h
+    # detector row and channel offsets
+    det_channel_offset = -np.dot(r_delta, r_h)
+    det_row_offset = -np.dot(r_delta, r_v)
+    # rotation offset
+    delta_source = r_s - project_vector_to_vector(r_s, r_n)
+    delta_rot = delta_source - project_vector_to_vector(delta_source, r_a)# rotation offset vector (perpendicular to rotation axis)
+    rotation_offset = np.dot(delta_rot, np.cross(r_n, r_a))
+    return det_channel_offset, det_row_offset, rotation_offset
+
+######## END subroutines for NSI-MBIR parameter conversion

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -13,10 +13,11 @@ __lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'mbircone')
 
 
 def _read_scan_img(img_path):
-    """Reads a single scan image from an image path.
+    """Reads a single scan image from an image path. This function is a subroutine to the function `_read_scan_dir`.
 
     Args:
-        img_path (string): Path to a ConeBeam scan image.
+        img_path (string): Path object or file object pointing to an image. 
+            The image type must be compatible with `PIL.Image.open()`. See `https://pillow.readthedocs.io/en/stable/reference/Image.html` for more details.
     Returns:
         ndarray (float): 2D numpy array. A single scan image.
     """
@@ -32,10 +33,11 @@ def _read_scan_img(img_path):
 
 
 def _read_scan_dir(scan_dir, view_ids=[]):
-    """Reads a stack of scan images from a directory.
+    """Reads a stack of scan images from a directory. This function is a subroutine to `NSI_load_scans_and_params`.
 
     Args:
-        scan_dir (string): Path to a ConeBeam Scan directory.
+        scan_dir (string): Path to a ConeBeam Scan directory. 
+            Example: "<absolute_path_to_dataset>/Radiographs"
         view_ids (list[int]): List of view indices to specify which scans to read.
     Returns:
         ndarray (float): 3D numpy array, (num_views, num_det_rows, num_det_channels). A stack of scan images.

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -291,10 +291,9 @@ def calc_row_channel_params(r_a, r_n, r_h, r_s, r_r, Delta_c, Delta_r, N_c, N_r)
 
 ######## END Functions for NSI-MBIR parameter conversion
 
-def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, dark_scan_path=None,
-                              geom_report_path=None,
-                              defective_pixel_path=None,
-                              #reference=None,
+def NSI_load_scans_and_params(config_file_path, geom_report_path, 
+                              obj_scan_path, blank_scan_path, dark_scan_path,
+                              defective_pixel_path,
                               downsample_factor=[1, 1], crop_factor=[(0, 0), (1, 1)],
                               view_id_start=0, view_angle_start=0.,
                               view_id_end=None, subsample_view_factor=1):
@@ -309,11 +308,11 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     **Arguments specific to file paths**:
 
         - config_file_path (string): Path to NSI configuration file. The filename extension is '.nsipro'.
+        - geom_report_path (string): Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
         - obj_scan_path (string): Path to an NSI radiograph directory.
-        - blank_scan_path (string): [Default=None] Path to a blank scan image, e.g. 'dataset_path/Corrections/gain0.tif'
-        - dark_scan_path (string): [Default=None] Path to a dark scan image, e.g. 'dataset_path/Corrections/offset.tif'
-        - geom_report_path (string): [Default=None] Path to "Geometry Report.rtf" file. This file contains more accurate information regarding the coordinates of the first detector row and column.
-        - defective_pixel_path (string): [Default=None] Path to the file containing defective pixel information, e.g. 'dataset_path/Corrections/defective_pixels.defect'
+        - blank_scan_path (string): Path to a blank scan image, e.g. 'dataset_path/Corrections/gain0.tif'
+        - dark_scan_path (string): Path to a dark scan image, e.g. 'dataset_path/Corrections/offset.tif'
+        - defective_pixel_path (string): Path to the file containing defective pixel information, e.g. 'dataset_path/Corrections/defective_pixels.defect'
 
     **Arguments specific to radiograph downsampling and cropping**:
 

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -236,20 +236,6 @@ def unit_vector(v):
     """ Normalize v. Returns v/||v|| """
     return v / np.linalg.norm(v)
 
-def angle_between(v1, v2):
-    """ Returns the angle in radians between vectors 'v1' and 'v2'::
-            >>> angle_between((1, 0, 0), (0, 1, 0))
-            1.5707963267948966
-            >>> angle_between((1, 0, 0), (1, 0, 0))
-            0.0
-            >>> angle_between((1, 0, 0), (-1, 0, 0))
-            3.141592653589793
-    """
-    v1_u = unit_vector(v1)
-    v2_u = unit_vector(v2)
-    return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0))
-
-
 def project_vector_to_vector(u1, u2):
     """ Projects the vector u1 onto the vector u2. Returns the vector <u1|u2>.
     """

--- a/mbircone/preprocess.py
+++ b/mbircone/preprocess.py
@@ -354,22 +354,21 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
     NSI_params = _NSI_read_str_from_config(config_file_path, tag_section_list)
 
     # coordinate of source
-    u_s = np.single(NSI_params[0].split(' ')[-1])
-
+    v_s = NSI_params[0].split(' ')
+    v_s = [np.single(i) for i in v_s]
+    
     # coordinate of reference
-    coordinate_ref = NSI_params[1].split(' ')
-    u_d1 = np.single(coordinate_ref[2])
-    v_d1 = np.single(coordinate_ref[0])
-    w_d1 = np.single(coordinate_ref[1])
-
+    v_r = NSI_params[1].split(' ')
+    v_r = [np.single(i) for i in v_r]
+ 
     # detector pixel pitch
     pixel_pitch_det = NSI_params[2].split(' ')
-    geo_params['delta_det_channel'] = np.single(pixel_pitch_det[0])
-    geo_params['delta_det_row'] = np.single(pixel_pitch_det[1])
+    Delta_c = np.single(pixel_pitch_det[0])
+    Delta_r = np.single(pixel_pitch_det[1])
 
     # dimension of radiograph
-    geo_params['num_det_channels'] = int(NSI_params[3])
-    geo_params['num_det_rows'] = int(NSI_params[4])
+    N_c = int(NSI_params[3])
+    N_r = int(NSI_params[4])
 
     # total number of radiograph scans
     num_acquired_scans = int(NSI_params[5])
@@ -408,21 +407,28 @@ def NSI_load_scans_and_params(config_file_path, obj_scan_path, blank_scan_path, 
         print("counter-clockwise rotation.")
         # counter-clockwise rotation
         angle_step = -angle_step
-    v_d0 = - v_d1
-    w_d0 = - w_d1
-    geo_params['rotation_offset'] = 0.0
 
     # Rotation axis
-    rot_axis = NSI_params[12].split(' ')
-    rot_axis = [np.single(rot_axis[i]) for i in range(len(rot_axis))]
-    
+    v_a = NSI_params[12].split(' ')
+    v_a = [np.single(i) for i in v_a]
+   
     # Detector normal vector
-    detector_normal = NSI_params[13].split(' ')
-    detector_normal = [np.single(detector_normal[i]) for i in range(len(detector_normal))]
-    
+    v_n = NSI_params[13].split(' ')
+    v_n = [np.single(i) for i in v_n]
+   
     # Detector horizontal vector
-    detector_horizontal = NSI_params[14].split(' ')
-    detector_horizontal = [np.single(detector_horizontal[i]) for i in range(len(detector_horizontal))]
+    v_h = NSI_params[14].split(' ')
+    v_h = [np.single(i) for i in v_h]
+
+    print("####### NSI parameters:")
+    print("vector from origin to source = ", v_s, " [mm]")
+    print("vector from origin to reference = ", v_r, " [mm]")
+    print("Unit vector of rotation axis = ", v_a)
+    print("Unit vector of normal = ", v_n)
+    print("Unit vector of horizontal = ", v_h)
+    print(f"Detector pixel pitch: (Delta_r, Delta_c) = ({Delta_r:.3f},{Delta_c:.3f}) [mm]")
+    print(f"Detector size: (N_r, N_c) = ({N_r},{N_c})")
+   
 
     ############### Adjust geometry NSI_params according to crop_factor and downsample_factor
     if isinstance(crop_factor[0], (list, tuple)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ dask-jobqueue~=0.7.3
 scikit-image
 docstring_inheritance
 h5py
+striprtf


### PR DESCRIPTION
### This PR contains the updates regarding the parameter calculation from NSI parameters to MBIR parameters.
### With this update, we are able to consistently produce high-resolution MBIR reconstructions for NSI datasets.

## Interface change
Function "NSI_load_scans_and_params" accepts a new variable "geom_report_path", which specifies the path to "Geometry Report.rtf" file.
![Screen Shot 2024-02-28 at 5 00 12 PM](https://github.com/cabouman/mbircone/assets/7671736/fc4045da-9d6f-4b62-a160-9c112378bc46)

## Implementation
This PR contains a lot of changes, but the core changes are the following two lines in "preprocess.py":
![Screen Shot 2024-02-28 at 2 56 38 PM](https://github.com/cabouman/mbircone/assets/7671736/32454b80-dfd7-4878-b018-c3faeb6a6cef)
These two lines correspond to the following two functions that we discussed and agreed on:
![Screen Shot 2024-02-28 at 5 18 50 PM](https://github.com/cabouman/mbircone/assets/7671736/22413d4f-8fb8-485f-8eb3-017da510f134)

## Dependency change:
A new dependency "striprtf" is added to "requirements.txt". This package is used to read rtf file.

## Image quality testing:
As we saw in my weekly slides, the image resolution is tested with five datasets. In all cases the nominal MBIR parameters produce the best reconstruction quality and resolution.

## Demo scripts: 
The NSI demo scripts are updated accordingly.
**you may run "demo_nsi_preprocess.py" to ensure that there are no bugs in the code.** I sent out the updated datasets in a separate email.